### PR TITLE
fix(guess): play v2 heardle audio on Safari via MP4/AAC fallback

### DIFF
--- a/apps/guess/messages/en-GB.json
+++ b/apps/guess/messages/en-GB.json
@@ -97,7 +97,8 @@
         "play": "Play clip",
         "pause": "Pause clip",
         "duration": "{seconds, plural, =1 {1 second} other {# seconds}}",
-        "step": "Clue {current} / {total}"
+        "step": "Clue {current} / {total}",
+        "error": "Couldn’t play audio: {detail}"
       }
     },
     "reveal": {

--- a/apps/guess/messages/en.json
+++ b/apps/guess/messages/en.json
@@ -110,7 +110,8 @@
         "play": "Play clip",
         "pause": "Pause clip",
         "duration": "{seconds, plural, =1 {1 second} other {# seconds}}",
-        "step": "Clue {current} / {total}"
+        "step": "Clue {current} / {total}",
+        "error": "Couldn’t play audio: {detail}"
       }
     },
     "reveal": {

--- a/apps/guess/messages/ja.json
+++ b/apps/guess/messages/ja.json
@@ -102,7 +102,8 @@
         "play": "再生",
         "pause": "停止",
         "duration": "{seconds}秒",
-        "step": "ヒント {current} / {total}"
+        "step": "ヒント {current} / {total}",
+        "error": "音声を再生できませんでした: {detail}"
       }
     },
     "reveal": {

--- a/apps/guess/messages/ko.json
+++ b/apps/guess/messages/ko.json
@@ -97,7 +97,8 @@
         "play": "재생",
         "pause": "일시정지",
         "duration": "{seconds}초",
-        "step": "힌트 {current} / {total}"
+        "step": "힌트 {current} / {total}",
+        "error": "오디오를 재생할 수 없습니다: {detail}"
       }
     },
     "reveal": {

--- a/apps/guess/messages/zh-CN.json
+++ b/apps/guess/messages/zh-CN.json
@@ -97,7 +97,8 @@
         "play": "播放",
         "pause": "暂停",
         "duration": "{seconds} 秒",
-        "step": "提示 {current} / {total}"
+        "step": "提示 {current} / {total}",
+        "error": "无法播放音频：{detail}"
       }
     },
     "reveal": {

--- a/apps/guess/messages/zh-HK.json
+++ b/apps/guess/messages/zh-HK.json
@@ -97,7 +97,8 @@
         "play": "播放",
         "pause": "暫停",
         "duration": "{seconds} 秒",
-        "step": "提示 {current} / {total}"
+        "step": "提示 {current} / {total}",
+        "error": "無法播放音訊：{detail}"
       }
     },
     "reveal": {

--- a/apps/guess/messages/zh-SG.json
+++ b/apps/guess/messages/zh-SG.json
@@ -97,7 +97,8 @@
         "play": "播放",
         "pause": "暂停",
         "duration": "{seconds} 秒",
-        "step": "提示 {current} / {total}"
+        "step": "提示 {current} / {total}",
+        "error": "无法播放音频：{detail}"
       }
     },
     "reveal": {

--- a/apps/guess/messages/zh-TW.json
+++ b/apps/guess/messages/zh-TW.json
@@ -97,7 +97,8 @@
         "play": "播放",
         "pause": "暫停",
         "duration": "{seconds} 秒",
-        "step": "提示 {current} / {total}"
+        "step": "提示 {current} / {total}",
+        "error": "無法播放音訊：{detail}"
       }
     },
     "reveal": {

--- a/apps/guess/src/app/api/audio/[date]/[level]/route.ts
+++ b/apps/guess/src/app/api/audio/[date]/[level]/route.ts
@@ -120,6 +120,39 @@ function ffmpegArgs(
   return args;
 }
 
+/**
+ * Parse a single-range `Range` header against a known total size. Returns the
+ * resolved inclusive `{ start, end }`, `null` when there's no usable range
+ * (caller serves the full body), or `"invalid"` for an unsatisfiable range
+ * (caller replies 416). Only the single-range forms browsers actually send
+ * are supported: `bytes=start-`, `bytes=start-end`, and suffix `bytes=-n`.
+ */
+function parseRange(
+  header: string,
+  total: number,
+): { start: number; end: number } | "invalid" | null {
+  const match = /^bytes=(\d*)-(\d*)$/.exec(header.trim());
+  if (!match) return null;
+  const [, startStr, endStr] = match;
+  if (startStr === "" && endStr === "") return null;
+
+  let start: number;
+  let end: number;
+  if (startStr === "") {
+    // Suffix range: last `n` bytes.
+    const n = Number.parseInt(endStr, 10);
+    if (n <= 0) return "invalid";
+    start = Math.max(0, total - n);
+    end = total - 1;
+  } else {
+    start = Number.parseInt(startStr, 10);
+    end = endStr === "" ? total - 1 : Number.parseInt(endStr, 10);
+    if (end >= total) end = total - 1;
+  }
+  if (start > end || start >= total) return "invalid";
+  return { start, end };
+}
+
 function runFfmpeg(args: string[]): Promise<Buffer> {
   return new Promise((resolve, reject) => {
     if (!ffmpegPath) {
@@ -198,11 +231,41 @@ export async function GET(
     cacheSet(cacheKey, buf);
   }
 
+  const contentType = format === "mp4" ? "audio/mp4" : "audio/webm";
+  const total = buf.length;
+  const baseHeaders: Record<string, string> = {
+    "Content-Type": contentType,
+    // Immutable: the (dateKey, level, fmt) tuple fully determines the bytes.
+    "Cache-Control": "public, max-age=86400, immutable",
+    // iOS Safari refuses to play media from a server that doesn't advertise
+    // and honour byte ranges — it probes with `Range: bytes=0-1` and expects
+    // a 206. Without this the source fails as MEDIA_ERR_SRC_NOT_SUPPORTED.
+    "Accept-Ranges": "bytes",
+  };
+
+  const rangeHeader = req.headers.get("range");
+  const range = rangeHeader ? parseRange(rangeHeader, total) : null;
+  if (range === "invalid") {
+    return new Response(null, {
+      status: 416,
+      headers: { ...baseHeaders, "Content-Range": `bytes */${total}` },
+    });
+  }
+  if (range) {
+    const { start, end } = range;
+    const chunk = buf.subarray(start, end + 1);
+    return new Response(new Uint8Array(chunk), {
+      status: 206,
+      headers: {
+        ...baseHeaders,
+        "Content-Range": `bytes ${start}-${end}/${total}`,
+        "Content-Length": String(chunk.length),
+      },
+    });
+  }
+
   return new Response(new Uint8Array(buf), {
-    headers: {
-      "Content-Type": format === "mp4" ? "audio/mp4" : "audio/webm",
-      // Immutable: the (dateKey, level) pair fully determines the bytes.
-      "Cache-Control": "public, max-age=86400, immutable",
-    },
+    status: 200,
+    headers: { ...baseHeaders, "Content-Length": String(total) },
   });
 }

--- a/apps/guess/src/app/api/audio/[date]/[level]/route.ts
+++ b/apps/guess/src/app/api/audio/[date]/[level]/route.ts
@@ -60,8 +60,18 @@ function resolveSlug(slug: string): string | null {
   return dateKey;
 }
 
+/** Output container/codec. WebM/Opus is small and efficient; MP4/AAC is the
+ * universal fallback for browsers (Safari/WebKit, incl. all of iOS) that
+ * can't decode Opus-in-WebM via `<audio>`. */
+type AudioFormat = "webm" | "mp4";
+
 /** Build the ffmpeg argv. `sourceSec` is the length of source to read. */
-function ffmpegArgs(sourceUrl: string, sourceSec: number, modifier: AudioModifier): string[] {
+function ffmpegArgs(
+  sourceUrl: string,
+  sourceSec: number,
+  modifier: AudioModifier,
+  format: AudioFormat,
+): string[] {
   // `-t` BEFORE `-i` caps how many seconds of input we read. Output length
   // is whatever the filter chain produces from that input: same for plain,
   // same for pitch (true pitch shift preserves length), `sourceSec / rate`
@@ -85,19 +95,28 @@ function ffmpegArgs(sourceUrl: string, sourceSec: number, modifier: AudioModifie
       `asetrate=44100*${factor.toFixed(6)},aresample=44100,atempo=${(1 / factor).toFixed(6)}`,
     );
   }
-  // Opus in WebM is universally supported in modern browsers, small, and
-  // streamable from stdout (unlike m4a, whose moov atom needs the whole
-  // file before it can be written).
-  args.push(
-    "-vn",
-    "-c:a",
-    "libopus",
-    "-b:a",
-    "96k",
-    "-f",
-    "webm",
-    "pipe:1",
-  );
+  args.push("-vn");
+  if (format === "mp4") {
+    // AAC in fragmented MP4. `+frag_keyframe+empty_moov+default_base_moof`
+    // lets the file stream from stdout without seeking back to write the moov
+    // atom — the reason plain m4a can't be piped. Plays in every modern
+    // browser, including Safari/WebKit, which can't decode Opus-in-WebM.
+    args.push(
+      "-c:a",
+      "aac",
+      "-b:a",
+      "96k",
+      "-movflags",
+      "+frag_keyframe+empty_moov+default_base_moof",
+      "-f",
+      "mp4",
+      "pipe:1",
+    );
+  } else {
+    // Opus in WebM: small, efficient, streamable from stdout. Supported by
+    // Chrome/Firefox/Edge but NOT Safari — clients negotiate via `?fmt`.
+    args.push("-c:a", "libopus", "-b:a", "96k", "-f", "webm", "pipe:1");
+  }
   return args;
 }
 
@@ -152,7 +171,12 @@ export async function GET(
     return NextResponse.json({ error: "level out of range" }, { status: 400 });
   }
 
-  const cacheKey = `${dateKey}:${level}`;
+  // Container negotiated by the client (see lib/audio-format.ts). Defaults to
+  // webm to preserve the original behaviour for any caller that omits `fmt`.
+  const format: AudioFormat =
+    req.nextUrl.searchParams.get("fmt") === "mp4" ? "mp4" : "webm";
+
+  const cacheKey = `${dateKey}:${level}:${format}`;
   let buf = cacheGet(cacheKey);
   if (!buf) {
     // Resolve the chart from the dateKey. `getToday` accepts an override; for
@@ -170,13 +194,13 @@ export async function GET(
     const pitchRoll = new Rng(`${dateKey}:audio:${level}:pitch`).intBelow(2);
     const modifier = audioModifier(2, level, variantRoll, pitchRoll);
     const sourceSec = sourceAudioDuration(level, modifier, 2);
-    buf = await runFfmpeg(ffmpegArgs(preview.previewUrl, sourceSec, modifier));
+    buf = await runFfmpeg(ffmpegArgs(preview.previewUrl, sourceSec, modifier, format));
     cacheSet(cacheKey, buf);
   }
 
   return new Response(new Uint8Array(buf), {
     headers: {
-      "Content-Type": "audio/webm",
+      "Content-Type": format === "mp4" ? "audio/mp4" : "audio/webm",
       // Immutable: the (dateKey, level) pair fully determines the bytes.
       "Cache-Control": "public, max-age=86400, immutable",
     },

--- a/apps/guess/src/components/AudioHintCard.tsx
+++ b/apps/guess/src/components/AudioHintCard.tsx
@@ -9,6 +9,7 @@ import { cn } from "@tomomai/ui/utils";
 import { Play, Pause, RotateCcw } from "lucide-react";
 import { useVolume, volumeToAmplitude } from "@/lib/use-volume";
 import { withAudioFormat } from "@/lib/audio-format";
+import { getAudioContext, unlockAudio, loadClip } from "@/lib/audio-engine";
 import { VolumeControl } from "./VolumeControl";
 import type { AudioModifier } from "@/lib/heardle-config";
 
@@ -34,27 +35,11 @@ function modifierLabel(m: AudioModifier | undefined): string | null {
   return `pitch ${m.semitones > 0 ? "+" : "−"}${Math.abs(m.semitones)}`;
 }
 
-/** Human-readable name for an HTMLMediaElement error code. */
-const MEDIA_ERR_NAMES: Record<number, string> = {
-  1: "aborted",
-  2: "network",
-  3: "decode",
-  4: "src-not-supported",
-};
-
-/** Build a compact, technical description of an audio failure for the toast.
- * Surfaces the media element's own MediaError when present (decode/format
- * problems set this), otherwise the thrown error from `play()`. */
-function describeAudioError(el: HTMLAudioElement | null, thrown?: unknown): string {
-  // Tag with the negotiated container so a lingering failure says which path
-  // (webm vs mp4) was tried.
-  const fmt = /[?&]fmt=([^&]+)/.exec(el?.currentSrc ?? "")?.[1];
+/** Compact, technical description of a playback failure for the toast. Tagged
+ * with the negotiated container so a lingering failure says which path (webm
+ * vs mp4) was tried. */
+function describeError(thrown: unknown, fmt?: string): string {
   const suffix = fmt ? ` (fmt=${fmt})` : "";
-  const me = el?.error;
-  if (me) {
-    const name = MEDIA_ERR_NAMES[me.code] ?? `code ${me.code}`;
-    return (me.message ? `${name} — ${me.message}` : name) + suffix;
-  }
   if (thrown instanceof Error) {
     return (thrown.message ? `${thrown.name}: ${thrown.message}` : thrown.name) + suffix;
   }
@@ -64,7 +49,8 @@ function describeAudioError(el: HTMLAudioElement | null, thrown?: unknown): stri
 /**
  * Heardle audio hint card. Plays a clipped window (`durationSec`) of the
  * Apple Music preview starting from t=0. Each hint level reveals a longer
- * window; same URL across levels so playback is instant on re-press.
+ * window; clips are decoded once and replayed from a buffer (see
+ * `lib/audio-engine.ts`) so playback is instant and reliable on iOS.
  */
 export function AudioHintCard({
   previewUrl,
@@ -78,48 +64,51 @@ export function AudioHintCard({
   const modLabel = modifierLabel(modifier);
   const playSec = audibleSec ?? durationSec;
   const t = useTranslations("guess.hints.audio");
-  const audioRef = useRef<HTMLAudioElement | null>(null);
+
+  const sourceRef = useRef<AudioBufferSourceNode | null>(null);
+  const gainRef = useRef<GainNode | null>(null);
+  const startRef = useRef(0); // AudioContext.currentTime when playback began
   const rafRef = useRef<number | null>(null);
   const [playing, setPlaying] = useState(false);
   const [progress, setProgress] = useState(0); // 0..1 of playSec
   const [volume] = useVolume();
 
   // The v2 route serves Opus/WebM or AAC/MP4; Safari can't decode the former,
-  // so we negotiate the container client-side via canPlayType. We resolve the
-  // URL only after mount: the empty initial state is identical on server and
-  // client (no hydration mismatch) and, crucially, stops Safari from ever
-  // fetching the unplayable bare (webm) URL before the format is chosen.
+  // so we negotiate the container client-side via canPlayType. Resolve the URL
+  // only after mount: the empty initial state is identical on server and client
+  // (no hydration mismatch) and keeps Safari from fetching an unplayable format.
   const [src, setSrc] = useState("");
   useEffect(() => {
     setSrc(withAudioFormat(previewUrl));
   }, [previewUrl]);
 
-  // Warm the HTTP cache for the focused card. iOS ignores `preload` until a
-  // user gesture, so without this the first press pays the full fetch latency
-  // before any sound — a plain fetch isn't gated by the gesture and the
-  // immutable response then satisfies the element's range requests from cache.
-  // Best-effort: failures are harmless (the element will fetch on play).
+  // Prewarm: fetch + decode the focused card's clip ahead of the first press so
+  // it plays instantly. Decoding works while the context is suspended.
   useEffect(() => {
     if (!isActive || !src) return;
-    const controller = new AbortController();
-    // Read the body to completion so the cache entry is fully written.
-    fetch(src, { signal: controller.signal })
-      .then((r) => r.arrayBuffer())
-      .catch(() => {});
-    return () => controller.abort();
+    loadClip(src).catch(() => {
+      // Surfaced when the user actually presses play; ignore here.
+    });
   }, [isActive, src]);
 
-  // Keep the audio element's volume in sync with the persisted setting.
-  useEffect(() => {
-    if (audioRef.current) audioRef.current.volume = volumeToAmplitude(volume);
-  }, [volume]);
+  const currentFmt = () => /[?&]fmt=([^&]+)/.exec(src)?.[1];
 
-  // Cleanly stop playback and clear timers.
+  // Tear down the current playback graph and reset the UI.
   const stop = () => {
-    const a = audioRef.current;
-    if (a) {
-      a.pause();
-      a.currentTime = 0;
+    const s = sourceRef.current;
+    if (s) {
+      s.onended = null; // prevent the natural-end handler from re-firing
+      try {
+        s.stop();
+      } catch {
+        // already stopped or ended
+      }
+      s.disconnect();
+      sourceRef.current = null;
+    }
+    if (gainRef.current) {
+      gainRef.current.disconnect();
+      gainRef.current = null;
     }
     if (rafRef.current != null) cancelAnimationFrame(rafRef.current);
     rafRef.current = null;
@@ -127,11 +116,11 @@ export function AudioHintCard({
     setProgress(0);
   };
 
-  // Stop whenever URL or playback length changes (e.g. moving between cards).
+  // Stop whenever the clip or playback length changes (e.g. moving cards).
   useEffect(() => {
     return () => stop();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [previewUrl, playSec]);
+  }, [src, playSec]);
 
   // Pause when this card stops being the active one — swipe, arrow buttons,
   // dot nav, submit, and skip all flip the deck through `isActive`.
@@ -140,43 +129,67 @@ export function AudioHintCard({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isActive]);
 
+  // Live volume changes during playback. Uses a GainNode because iOS ignores
+  // HTMLMediaElement.volume entirely.
+  useEffect(() => {
+    if (gainRef.current) gainRef.current.gain.value = volumeToAmplitude(volume);
+  }, [volume]);
+
   const play = async () => {
-    const a = audioRef.current;
-    if (!a || !previewUrl) return;
-    try {
-      a.currentTime = 0;
-      await a.play();
-    } catch (err) {
-      // Surface the failure so issues like Safari refusing the codec, an
-      // autoplay-policy block, or a failed fetch are visible instead of the
-      // button silently doing nothing.
-      toast.error(t("error", { detail: describeAudioError(a, err) }), {
+    if (!src) return;
+    const ctx = getAudioContext();
+    if (!ctx) {
+      toast.error(t("error", { detail: "Web Audio unavailable" }), {
         id: "audio-error",
       });
       return;
     }
-    setPlaying(true);
-    // Drive progress off the element's real playback position, not a
-    // wall-clock timer. On iOS the first press has real startup latency (the
-    // range-request handshake + clip fetch), so a wall-clock timer would
-    // "end" the clip before any sound came out — leaving the progress ring
-    // sweeping over silence. Reading `currentTime` means the ring only moves
-    // once audio is actually playing, and the clip ends when it truly ends.
-    const tick = () => {
-      const el = audioRef.current;
-      // Bail if we've been stopped/paused (stop() pauses the element).
-      if (!el || el.paused) return;
-      if (el.currentTime >= playSec) {
+    // Synchronously, still inside the click gesture: unlock audio output so iOS
+    // doesn't mute the first clip.
+    unlockAudio(ctx);
+    try {
+      if (ctx.state !== "running") await ctx.resume();
+      const buffer = await loadClip(src);
+
+      stop(); // clear any prior graph before starting a new one
+      const source = ctx.createBufferSource();
+      source.buffer = buffer;
+      const gain = ctx.createGain();
+      gain.gain.value = volumeToAmplitude(volume);
+      source.connect(gain).connect(ctx.destination);
+      sourceRef.current = source;
+      gainRef.current = gain;
+
+      source.onended = () => {
         // Subtle tactile cue that the clip just ended — distinct from the
-        // firmer "medium" press the user feels when they trigger play/pause.
+        // firmer "medium" press felt when triggering play/pause.
         triggerHaptic("soft");
         stop();
-        return;
-      }
-      setProgress(Math.min(1, el.currentTime / playSec));
+      };
+      // Clips are already trimmed server-side; cap the duration defensively so
+      // the audio and the progress ring always agree on the end.
+      source.start(0, 0, playSec);
+      startRef.current = ctx.currentTime;
+      setPlaying(true);
+
+      const tick = () => {
+        const elapsed = ctx.currentTime - startRef.current;
+        if (elapsed >= playSec) {
+          setProgress(1); // onended resets shortly after
+          return;
+        }
+        setProgress(elapsed / playSec);
+        rafRef.current = requestAnimationFrame(tick);
+      };
       rafRef.current = requestAnimationFrame(tick);
-    };
-    rafRef.current = requestAnimationFrame(tick);
+    } catch (err) {
+      // Surface failures (decode error, failed fetch, unsupported codec)
+      // instead of the button silently doing nothing.
+      toast.error(t("error", { detail: describeError(err, currentFmt()) }), {
+        id: "audio-error",
+      });
+      stop();
+    }
   };
 
   const onPress = () => {
@@ -190,30 +203,6 @@ export function AudioHintCard({
   return (
     <Card className="p-0 border-2 border-border shadow-lg">
       <CardContent className="relative aspect-square flex flex-col items-center justify-center text-center gap-5 px-6">
-        {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
-        <audio
-          ref={audioRef}
-          // Omit (rather than empty) when there's no clip: an empty src
-          // resolves to the page URL and would fire a bogus load error.
-          src={src || undefined}
-          preload="auto"
-          onEnded={stop}
-          onError={() => {
-            const a = audioRef.current;
-            // Ignore aborts — those come from our own src swap (format
-            // negotiation) or stop(), not a real failure. Surface genuine
-            // load/decode errors (bad fetch, unsupported codec). Shares an id
-            // with the play() catch so the two paths collapse into one toast.
-            if (!a?.error || a.error.code === a.error.MEDIA_ERR_ABORTED) return;
-            toast.error(t("error", { detail: describeAudioError(a) }), {
-              id: "audio-error",
-            });
-            // Reset the UI: an error mid-playback otherwise leaves the button
-            // stuck on "pause" with the progress loop spinning over silence.
-            stop();
-          }}
-        />
-
         <div className="absolute top-2 right-2">
           <VolumeControl variant="card" />
         </div>

--- a/apps/guess/src/components/AudioHintCard.tsx
+++ b/apps/guess/src/components/AudioHintCard.tsx
@@ -79,7 +79,6 @@ export function AudioHintCard({
   const playSec = audibleSec ?? durationSec;
   const t = useTranslations("guess.hints.audio");
   const audioRef = useRef<HTMLAudioElement | null>(null);
-  const stopAtRef = useRef<number | null>(null);
   const rafRef = useRef<number | null>(null);
   const [playing, setPlaying] = useState(false);
   const [progress, setProgress] = useState(0); // 0..1 of playSec
@@ -95,6 +94,21 @@ export function AudioHintCard({
     setSrc(withAudioFormat(previewUrl));
   }, [previewUrl]);
 
+  // Warm the HTTP cache for the focused card. iOS ignores `preload` until a
+  // user gesture, so without this the first press pays the full fetch latency
+  // before any sound — a plain fetch isn't gated by the gesture and the
+  // immutable response then satisfies the element's range requests from cache.
+  // Best-effort: failures are harmless (the element will fetch on play).
+  useEffect(() => {
+    if (!isActive || !src) return;
+    const controller = new AbortController();
+    // Read the body to completion so the cache entry is fully written.
+    fetch(src, { signal: controller.signal })
+      .then((r) => r.arrayBuffer())
+      .catch(() => {});
+    return () => controller.abort();
+  }, [isActive, src]);
+
   // Keep the audio element's volume in sync with the persisted setting.
   useEffect(() => {
     if (audioRef.current) audioRef.current.volume = volumeToAmplitude(volume);
@@ -107,7 +121,6 @@ export function AudioHintCard({
       a.pause();
       a.currentTime = 0;
     }
-    stopAtRef.current = null;
     if (rafRef.current != null) cancelAnimationFrame(rafRef.current);
     rafRef.current = null;
     setPlaying(false);
@@ -143,18 +156,24 @@ export function AudioHintCard({
       return;
     }
     setPlaying(true);
-    stopAtRef.current = performance.now() + playSec * 1000;
+    // Drive progress off the element's real playback position, not a
+    // wall-clock timer. On iOS the first press has real startup latency (the
+    // range-request handshake + clip fetch), so a wall-clock timer would
+    // "end" the clip before any sound came out — leaving the progress ring
+    // sweeping over silence. Reading `currentTime` means the ring only moves
+    // once audio is actually playing, and the clip ends when it truly ends.
     const tick = () => {
-      if (stopAtRef.current == null) return;
-      const remaining = stopAtRef.current - performance.now();
-      if (remaining <= 0) {
+      const el = audioRef.current;
+      // Bail if we've been stopped/paused (stop() pauses the element).
+      if (!el || el.paused) return;
+      if (el.currentTime >= playSec) {
         // Subtle tactile cue that the clip just ended — distinct from the
         // firmer "medium" press the user feels when they trigger play/pause.
         triggerHaptic("soft");
         stop();
         return;
       }
-      setProgress(1 - remaining / (playSec * 1000));
+      setProgress(Math.min(1, el.currentTime / playSec));
       rafRef.current = requestAnimationFrame(tick);
     };
     rafRef.current = requestAnimationFrame(tick);
@@ -189,6 +208,9 @@ export function AudioHintCard({
             toast.error(t("error", { detail: describeAudioError(a) }), {
               id: "audio-error",
             });
+            // Reset the UI: an error mid-playback otherwise leaves the button
+            // stuck on "pause" with the progress loop spinning over silence.
+            stop();
           }}
         />
 

--- a/apps/guess/src/components/AudioHintCard.tsx
+++ b/apps/guess/src/components/AudioHintCard.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import { useTranslations } from "next-intl";
+import { toast } from "sonner";
 import { Card, CardContent } from "@tomomai/ui";
 import { triggerHaptic } from "@tomomai/ui/haptics";
 import { cn } from "@tomomai/ui/utils";
@@ -33,6 +34,29 @@ function modifierLabel(m: AudioModifier | undefined): string | null {
   return `pitch ${m.semitones > 0 ? "+" : "−"}${Math.abs(m.semitones)}`;
 }
 
+/** Human-readable name for an HTMLMediaElement error code. */
+const MEDIA_ERR_NAMES: Record<number, string> = {
+  1: "aborted",
+  2: "network",
+  3: "decode",
+  4: "src-not-supported",
+};
+
+/** Build a compact, technical description of an audio failure for the toast.
+ * Surfaces the media element's own MediaError when present (decode/format
+ * problems set this), otherwise the thrown error from `play()`. */
+function describeAudioError(el: HTMLAudioElement | null, thrown?: unknown): string {
+  const me = el?.error;
+  if (me) {
+    const name = MEDIA_ERR_NAMES[me.code] ?? `code ${me.code}`;
+    return me.message ? `${name} — ${me.message}` : name;
+  }
+  if (thrown instanceof Error) {
+    return thrown.message ? `${thrown.name}: ${thrown.message}` : thrown.name;
+  }
+  return thrown ? String(thrown) : "unknown error";
+}
+
 /**
  * Heardle audio hint card. Plays a clipped window (`durationSec`) of the
  * Apple Music preview starting from t=0. Each hint level reveals a longer
@@ -57,11 +81,12 @@ export function AudioHintCard({
   const [progress, setProgress] = useState(0); // 0..1 of playSec
   const [volume] = useVolume();
 
-  // The v2 route can serve Opus/WebM or AAC/MP4; Safari can't decode the
-  // former, so we negotiate the container client-side. SSR renders the bare
-  // `previewUrl` (no `?fmt`) and we resolve it after mount — keeping the
-  // initial markup identical avoids a hydration mismatch on the <audio> src.
-  const [src, setSrc] = useState(previewUrl);
+  // The v2 route serves Opus/WebM or AAC/MP4; Safari can't decode the former,
+  // so we negotiate the container client-side via canPlayType. We resolve the
+  // URL only after mount: the empty initial state is identical on server and
+  // client (no hydration mismatch) and, crucially, stops Safari from ever
+  // fetching the unplayable bare (webm) URL before the format is chosen.
+  const [src, setSrc] = useState("");
   useEffect(() => {
     setSrc(withAudioFormat(previewUrl));
   }, [previewUrl]);
@@ -101,11 +126,16 @@ export function AudioHintCard({
   const play = async () => {
     const a = audioRef.current;
     if (!a || !previewUrl) return;
-    a.currentTime = 0;
     try {
+      a.currentTime = 0;
       await a.play();
-    } catch {
-      // Autoplay policy or another race — ignore; user can re-click.
+    } catch (err) {
+      // Surface the failure so issues like Safari refusing the codec, an
+      // autoplay-policy block, or a failed fetch are visible instead of the
+      // button silently doing nothing.
+      toast.error(t("error", { detail: describeAudioError(a, err) }), {
+        id: "audio-error",
+      });
       return;
     }
     setPlaying(true);
@@ -140,9 +170,22 @@ export function AudioHintCard({
         {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
         <audio
           ref={audioRef}
-          src={src}
+          // Omit (rather than empty) when there's no clip: an empty src
+          // resolves to the page URL and would fire a bogus load error.
+          src={src || undefined}
           preload="auto"
           onEnded={stop}
+          onError={() => {
+            const a = audioRef.current;
+            // Ignore aborts — those come from our own src swap (format
+            // negotiation) or stop(), not a real failure. Surface genuine
+            // load/decode errors (bad fetch, unsupported codec). Shares an id
+            // with the play() catch so the two paths collapse into one toast.
+            if (!a?.error || a.error.code === a.error.MEDIA_ERR_ABORTED) return;
+            toast.error(t("error", { detail: describeAudioError(a) }), {
+              id: "audio-error",
+            });
+          }}
         />
 
         <div className="absolute top-2 right-2">

--- a/apps/guess/src/components/AudioHintCard.tsx
+++ b/apps/guess/src/components/AudioHintCard.tsx
@@ -6,10 +6,10 @@ import { toast } from "sonner";
 import { Card, CardContent } from "@tomomai/ui";
 import { triggerHaptic } from "@tomomai/ui/haptics";
 import { cn } from "@tomomai/ui/utils";
-import { Play, Pause, RotateCcw } from "lucide-react";
+import { Play, Pause, RotateCcw, Loader2 } from "lucide-react";
 import { useVolume, volumeToAmplitude } from "@/lib/use-volume";
 import { withAudioFormat } from "@/lib/audio-format";
-import { getAudioContext, unlockAudio, loadClip } from "@/lib/audio-engine";
+import { getAudioContext, unlockAudio, loadClip, isClipReady } from "@/lib/audio-engine";
 import { VolumeControl } from "./VolumeControl";
 import type { AudioModifier } from "@/lib/heardle-config";
 
@@ -69,7 +69,12 @@ export function AudioHintCard({
   const gainRef = useRef<GainNode | null>(null);
   const startRef = useRef(0); // AudioContext.currentTime when playback began
   const rafRef = useRef<number | null>(null);
+  // Bumped on every stop/new play so an in-flight play() can tell it was
+  // cancelled (user pressed again, or the card changed) while it awaited the
+  // clip, and bail instead of starting stale audio.
+  const playTokenRef = useRef(0);
   const [playing, setPlaying] = useState(false);
+  const [loading, setLoading] = useState(false);
   const [progress, setProgress] = useState(0); // 0..1 of playSec
   const [volume] = useVolume();
 
@@ -93,8 +98,8 @@ export function AudioHintCard({
 
   const currentFmt = () => /[?&]fmt=([^&]+)/.exec(src)?.[1];
 
-  // Tear down the current playback graph and reset the UI.
-  const stop = () => {
+  // Tear down the audio graph without touching React state or the play token.
+  const teardownGraph = () => {
     const s = sourceRef.current;
     if (s) {
       s.onended = null; // prevent the natural-end handler from re-firing
@@ -112,7 +117,14 @@ export function AudioHintCard({
     }
     if (rafRef.current != null) cancelAnimationFrame(rafRef.current);
     rafRef.current = null;
+  };
+
+  // User-facing stop: cancel any in-flight play(), tear down, reset the UI.
+  const stop = () => {
+    playTokenRef.current++;
+    teardownGraph();
     setPlaying(false);
+    setLoading(false);
     setProgress(0);
   };
 
@@ -147,11 +159,17 @@ export function AudioHintCard({
     // Synchronously, still inside the click gesture: unlock audio output so iOS
     // doesn't mute the first clip.
     unlockAudio(ctx);
+    const token = ++playTokenRef.current;
+    // Show the spinner only when the clip isn't decoded yet — prewarmed clips
+    // start instantly, so this avoids a flicker on the common path.
+    if (!isClipReady(src)) setLoading(true);
     try {
       if (ctx.state !== "running") await ctx.resume();
       const buffer = await loadClip(src);
+      // Bail if the user stopped/re-pressed or the card changed while we waited.
+      if (token !== playTokenRef.current) return;
 
-      stop(); // clear any prior graph before starting a new one
+      teardownGraph(); // clear any prior graph before starting a new one
       const source = ctx.createBufferSource();
       source.buffer = buffer;
       const gain = ctx.createGain();
@@ -170,6 +188,7 @@ export function AudioHintCard({
       // the audio and the progress ring always agree on the end.
       source.start(0, 0, playSec);
       startRef.current = ctx.currentTime;
+      setLoading(false);
       setPlaying(true);
 
       const tick = () => {
@@ -183,6 +202,7 @@ export function AudioHintCard({
       };
       rafRef.current = requestAnimationFrame(tick);
     } catch (err) {
+      if (token !== playTokenRef.current) return; // superseded; stay quiet
       // Surface failures (decode error, failed fetch, unsupported codec)
       // instead of the button silently doing nothing.
       toast.error(t("error", { detail: describeError(err, currentFmt()) }), {
@@ -194,7 +214,8 @@ export function AudioHintCard({
 
   const onPress = () => {
     triggerHaptic("medium");
-    if (playing) stop();
+    // While loading, a second press cancels (stop() bumps the play token).
+    if (playing || loading) stop();
     else play();
   };
 
@@ -221,6 +242,7 @@ export function AudioHintCard({
           type="button"
           onClick={onPress}
           disabled={disabled}
+          aria-busy={loading}
           aria-label={playing ? t("pause") : t("play")}
           className={cn(
             "relative h-24 w-24 rounded-full flex items-center justify-center transition-all",
@@ -258,7 +280,9 @@ export function AudioHintCard({
               style={{ transition: playing ? undefined : "stroke-dashoffset 200ms" }}
             />
           </svg>
-          {playing ? (
+          {loading ? (
+            <Loader2 className="h-9 w-9 relative animate-spin" />
+          ) : playing ? (
             <Pause className="h-10 w-10 relative" fill="currentColor" />
           ) : progress > 0 ? (
             <RotateCcw className="h-9 w-9 relative" />

--- a/apps/guess/src/components/AudioHintCard.tsx
+++ b/apps/guess/src/components/AudioHintCard.tsx
@@ -46,15 +46,19 @@ const MEDIA_ERR_NAMES: Record<number, string> = {
  * Surfaces the media element's own MediaError when present (decode/format
  * problems set this), otherwise the thrown error from `play()`. */
 function describeAudioError(el: HTMLAudioElement | null, thrown?: unknown): string {
+  // Tag with the negotiated container so a lingering failure says which path
+  // (webm vs mp4) was tried.
+  const fmt = /[?&]fmt=([^&]+)/.exec(el?.currentSrc ?? "")?.[1];
+  const suffix = fmt ? ` (fmt=${fmt})` : "";
   const me = el?.error;
   if (me) {
     const name = MEDIA_ERR_NAMES[me.code] ?? `code ${me.code}`;
-    return me.message ? `${name} — ${me.message}` : name;
+    return (me.message ? `${name} — ${me.message}` : name) + suffix;
   }
   if (thrown instanceof Error) {
-    return thrown.message ? `${thrown.name}: ${thrown.message}` : thrown.name;
+    return (thrown.message ? `${thrown.name}: ${thrown.message}` : thrown.name) + suffix;
   }
-  return thrown ? String(thrown) : "unknown error";
+  return (thrown ? String(thrown) : "unknown error") + suffix;
 }
 
 /**

--- a/apps/guess/src/components/AudioHintCard.tsx
+++ b/apps/guess/src/components/AudioHintCard.tsx
@@ -7,6 +7,7 @@ import { triggerHaptic } from "@tomomai/ui/haptics";
 import { cn } from "@tomomai/ui/utils";
 import { Play, Pause, RotateCcw } from "lucide-react";
 import { useVolume, volumeToAmplitude } from "@/lib/use-volume";
+import { withAudioFormat } from "@/lib/audio-format";
 import { VolumeControl } from "./VolumeControl";
 import type { AudioModifier } from "@/lib/heardle-config";
 
@@ -55,6 +56,15 @@ export function AudioHintCard({
   const [playing, setPlaying] = useState(false);
   const [progress, setProgress] = useState(0); // 0..1 of playSec
   const [volume] = useVolume();
+
+  // The v2 route can serve Opus/WebM or AAC/MP4; Safari can't decode the
+  // former, so we negotiate the container client-side. SSR renders the bare
+  // `previewUrl` (no `?fmt`) and we resolve it after mount — keeping the
+  // initial markup identical avoids a hydration mismatch on the <audio> src.
+  const [src, setSrc] = useState(previewUrl);
+  useEffect(() => {
+    setSrc(withAudioFormat(previewUrl));
+  }, [previewUrl]);
 
   // Keep the audio element's volume in sync with the persisted setting.
   useEffect(() => {
@@ -130,7 +140,7 @@ export function AudioHintCard({
         {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
         <audio
           ref={audioRef}
-          src={previewUrl}
+          src={src}
           preload="auto"
           onEnded={stop}
         />

--- a/apps/guess/src/lib/audio-engine.ts
+++ b/apps/guess/src/lib/audio-engine.ts
@@ -1,0 +1,111 @@
+"use client";
+
+/**
+ * Minimal Web Audio engine for heardle clips.
+ *
+ * Playing short clips through a shared AudioContext — rather than an `<audio>`
+ * element — sidesteps a pile of iOS WebKit problems we kept hitting:
+ *   - the first `<audio>` play after a user gesture is silent;
+ *   - `HTMLMediaElement.volume` is read-only, so the volume slider does nothing;
+ *   - media playback demands server byte-range support;
+ *   - `currentTime` polling is too coarse for a smooth progress ring.
+ *
+ * An AudioContext unlocked inside the gesture outputs sound reliably, a
+ * GainNode gives real volume control, and `AudioContext.currentTime` is
+ * high-resolution. Clips are tiny and we fetch the bytes anyway, so decoding
+ * them up front costs little.
+ */
+
+let ctx: AudioContext | null = null;
+
+/** Lazily create the shared AudioContext. iOS caps the number of live contexts,
+ * so every card shares one. Returns null when Web Audio is unavailable. */
+export function getAudioContext(): AudioContext | null {
+  if (typeof window === "undefined") return null;
+  if (!ctx) {
+    const Ctor =
+      window.AudioContext ??
+      (window as unknown as { webkitAudioContext?: typeof AudioContext })
+        .webkitAudioContext;
+    if (!Ctor) return null;
+    ctx = new Ctor();
+  }
+  return ctx;
+}
+
+let unlocked = false;
+
+/**
+ * Unlock audio output. Must be called synchronously inside a user gesture
+ * (e.g. the play button's click handler, before any `await`). Resuming the
+ * context and starting a one-sample silent buffer in the same gesture is the
+ * combination WebKit needs to stop muting the first real clip. No-op after the
+ * first successful call.
+ */
+export function unlockAudio(context: AudioContext): void {
+  if (unlocked) return;
+  unlocked = true;
+  void context.resume();
+  try {
+    const buffer = context.createBuffer(1, 1, 22050);
+    const source = context.createBufferSource();
+    source.buffer = buffer;
+    source.connect(context.destination);
+    source.start(0);
+  } catch {
+    // Best-effort; resume() alone is usually enough.
+  }
+}
+
+// Decoded clips keyed by URL. Clips are tiny and immutable, so holding the last
+// several avoids re-fetching/decoding on replay or when stepping back through
+// levels.
+const DECODE_CACHE_MAX = 16;
+const decoded = new Map<string, AudioBuffer>();
+const inflight = new Map<string, Promise<AudioBuffer>>();
+
+/**
+ * Fetch and decode a clip URL into an AudioBuffer, memoised per URL. Safe to
+ * call ahead of time (prewarm): decoding works while the context is suspended,
+ * so the buffer is ready the instant the user presses play. Concurrent calls
+ * for the same URL share one fetch.
+ */
+export function loadClip(url: string): Promise<AudioBuffer> {
+  const hit = decoded.get(url);
+  if (hit) return Promise.resolve(hit);
+  const pending = inflight.get(url);
+  if (pending) return pending;
+
+  const context = getAudioContext();
+  if (!context) return Promise.reject(new Error("Web Audio unavailable"));
+
+  const p = fetch(url)
+    .then((r) => {
+      if (!r.ok) throw new Error(`fetch failed: ${r.status}`);
+      return r.arrayBuffer();
+    })
+    // Some WebKit builds only support the callback form of decodeAudioData, so
+    // wrap it rather than relying on the returned promise.
+    .then(
+      (bytes) =>
+        new Promise<AudioBuffer>((resolve, reject) => {
+          context.decodeAudioData(bytes, resolve, reject);
+        }),
+    )
+    .then((audio) => {
+      decoded.set(url, audio);
+      if (decoded.size > DECODE_CACHE_MAX) {
+        const oldest = decoded.keys().next().value;
+        if (oldest !== undefined) decoded.delete(oldest);
+      }
+      inflight.delete(url);
+      return audio;
+    })
+    .catch((err) => {
+      inflight.delete(url);
+      throw err;
+    });
+
+  inflight.set(url, p);
+  return p;
+}

--- a/apps/guess/src/lib/audio-engine.ts
+++ b/apps/guess/src/lib/audio-engine.ts
@@ -109,3 +109,9 @@ export function loadClip(url: string): Promise<AudioBuffer> {
   inflight.set(url, p);
   return p;
 }
+
+/** Whether a clip is already decoded and will play with no fetch/decode wait.
+ * Lets the UI skip the loading state for prewarmed clips (no spinner flicker). */
+export function isClipReady(url: string): boolean {
+  return decoded.has(url);
+}

--- a/apps/guess/src/lib/audio-format.ts
+++ b/apps/guess/src/lib/audio-format.ts
@@ -1,0 +1,40 @@
+/**
+ * Client-side audio format negotiation for the v2 `/api/audio` route.
+ *
+ * The server can encode the clip as either Opus-in-WebM (small, efficient)
+ * or AAC-in-fragmented-MP4 (universal). Safari/WebKit — including every
+ * browser on iOS — does not reliably decode Opus-in-WebM via `<audio>`, so
+ * playback silently fails there. We pick the best container the current
+ * browser can actually play and pass it to the route as `?fmt=`.
+ */
+
+export type AudioFormat = "webm" | "mp4";
+
+let cached: AudioFormat | null = null;
+
+/**
+ * Best supported clip format for this browser. Prefers `webm` (Opus) when the
+ * browser reports it can play it, otherwise falls back to `mp4` (AAC), which
+ * Safari and every other modern browser support. SSR-safe: returns `webm` on
+ * the server (the value is only consumed client-side after mount).
+ */
+export function pickAudioFormat(): AudioFormat {
+  if (cached) return cached;
+  if (typeof document === "undefined") return "webm";
+  const probe = document.createElement("audio");
+  const webmOpus = probe.canPlayType('audio/webm; codecs="opus"');
+  // `canPlayType` returns "probably" | "maybe" | "". Safari returns "" for
+  // webm/opus; Chrome/Firefox return "probably".
+  cached = webmOpus === "probably" || webmOpus === "maybe" ? "webm" : "mp4";
+  return cached;
+}
+
+/**
+ * Append the negotiated `fmt` to a v2 audio URL. Leaves non-route URLs (the
+ * direct Apple preview used by v1 puzzles and the reveal button) untouched.
+ */
+export function withAudioFormat(url: string): string {
+  if (!url.startsWith("/api/audio/")) return url;
+  const sep = url.includes("?") ? "&" : "?";
+  return `${url}${sep}fmt=${pickAudioFormat()}`;
+}


### PR DESCRIPTION
The v2 audio route encoded clips as Opus-in-WebM, which Safari/WebKit
(including every browser on iOS) cannot decode through <audio>, so
playback silently failed. v1 puzzles were unaffected because they play
the direct Apple AAC preview.

The route now serves AAC in fragmented MP4 (streamable from stdout via
+frag_keyframe+empty_moov+default_base_moof) when the client requests
?fmt=mp4, keeping the smaller Opus/WebM for browsers that support it.
Clients negotiate the container with canPlayType and append the format
to the URL; the response Content-Type and in-memory cache key vary by
format. Default stays webm so callers omitting fmt are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-format audio delivery (MP4/AAC and WebM/Opus) with negotiated format selection and format-aware caching.
  * Client-side Web Audio playback engine: preloading/decoding, resumable playback, progress UI, and live volume control.
* **Localization**
  * Added localized error messages for audio playback failures in multiple languages.
* **Bug Fixes**
  * Better handling of unsupported formats and clearer playback error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->