### PR TITLE
Default max reserved profile to the first enabled region

### DIFF
--- a/apps/main/src/server/queries/reserved.ts
+++ b/apps/main/src/server/queries/reserved.ts
@@ -24,7 +24,7 @@ const RESERVED_PROFILES: Record<string, ReservedProfile> = {
     userId: "reserved-max",
     username: "max",
     displayName: "\uff4d\uff41\uff58\uff52\uff41\uff54\uff49\uff4e\uff47", // ｍａｘｒａｔｉｎｇ
-    profileMainRegion: getEnabledRegions()[getEnabledRegions().length - 1],
+    profileMainRegion: getEnabledRegions()[0],
   },
 };
 


### PR DESCRIPTION
The max reserved profile picked the last enabled region as its main
region, which resolved to cn (china) on the intl,jp,cn build, so
/profile/max redirected to the China region. Use the first enabled
region instead.