### PR TITLE
fix(guess): play heardle audio in iOS silent mode

### DIFF
--- a/apps/guess/src/lib/audio-engine.ts
+++ b/apps/guess/src/lib/audio-engine.ts
@@ -36,6 +36,28 @@ export function getAudioContext(): AudioContext | null {
 let unlocked = false;
 
 /**
+ * iOS gives Web Audio the "ambient" audio session category by default, which
+ * the hardware mute switch silences — unlike `<audio>` elements, which use
+ * "playback" and keep sounding in silent mode. Opt into "playback" via the
+ * WebKit Audio Session API (Safari 16.4+) so heardle clips are audible with the
+ * ringer off, matching the old `<audio>`-based behaviour. No-op where the API
+ * is absent (older iOS, non-WebKit browsers — which don't mute Web Audio
+ * anyway).
+ */
+function preferPlaybackAudioSession(): void {
+  if (typeof navigator === "undefined") return;
+  const session = (
+    navigator as Navigator & { audioSession?: { type: string } }
+  ).audioSession;
+  if (!session) return;
+  try {
+    session.type = "playback";
+  } catch {
+    // Some engines expose the object but reject unknown values; ignore.
+  }
+}
+
+/**
  * Unlock audio output. Must be called synchronously inside a user gesture
  * (e.g. the play button's click handler, before any `await`). Resuming the
  * context and starting a one-sample silent buffer in the same gesture is the
@@ -45,6 +67,8 @@ let unlocked = false;
 export function unlockAudio(context: AudioContext): void {
   if (unlocked) return;
   unlocked = true;
+  // Route through the "playback" session so the mute switch doesn't silence us.
+  preferPlaybackAudioSession();
   void context.resume();
   try {
     const buffer = context.createBuffer(1, 1, 22050);


### PR DESCRIPTION
## Problem

After moving heardle clip playback to the Web Audio API, audio stopped playing on iPhones with the **ringer/mute switch off**. The old `<audio>`-based v1 worked fine in silent mode.

This is down to the iOS **audio session category**:
- `<audio>`/`<video>` elements use the **"playback"** category → **ignores the mute switch** (v1 behaviour).
- The Web Audio `AudioContext` defaults to the **"ambient"** category → **obeys the mute switch**.

So the Web Audio switch inadvertently opted clips into a category the ringer switch silences.

## Fix

Opt the page into the **"playback"** session via the WebKit Audio Session API during the existing first-gesture unlock:

```js
navigator.audioSession.type = "playback";
```

- Set in `unlockAudio` (already gated to run once, inside the user gesture).
- Feature-detected and wrapped in `try/catch`, so it's a **no-op** on:
  - older iOS (< 16.4) without the API, and
  - non-WebKit browsers (Chrome/Firefox), which don't mute Web Audio anyway.

## Tradeoff

The "playback" category is non-mixing, so while a clip plays it may pause/duck the user's background music. For a listening game this is the expected behaviour and matches v1.

## Not covered

iPhones on iOS < 16.4 (no Audio Session API) remain subject to the mute switch. If that traffic matters, the follow-up is to route Web Audio output through a hidden `<audio>` element via `MediaStreamAudioDestinationNode` (feature-detected fallback).

## Testing

- `tsc --noEmit` clean
- lint clean
- Behaviour change is iOS-only and needs on-device verification (ringer off → clip audible).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed audio clips being silenced by the hardware mute switch on iOS devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->