### PR TITLE
refactor(main/discord): unify region command pairs and simplify /fetch and /profile

### DIFF
--- a/apps/main/scripts/register-discord-commands.js
+++ b/apps/main/scripts/register-discord-commands.js
@@ -7,6 +7,31 @@ config({ path: ".env.local" });
 const APPLICATION_ID = process.env.NEXT_PUBLIC_DISCORD_APPLICATION_ID;
 const BOT_TOKEN = process.env.DISCORD_BOT_TOKEN;
 
+// Mirror of getEnabledRegions() from src/lib/enabled-regions.ts (this is a
+// plain Node script and cannot import the TS module).
+const REGION_LABELS = { intl: 'International', jp: 'Japan', cn: 'China' };
+
+function getEnabledRegions() {
+  const envValue = process.env.NEXT_PUBLIC_ENABLED_REGIONS;
+  if (!envValue) return ['intl', 'jp'];
+  const regions = envValue
+    .split(',')
+    .map(r => r.trim())
+    .filter(r => r === 'intl' || r === 'jp' || r === 'cn');
+  return regions.length === 0 ? ['intl', 'jp'] : regions;
+}
+
+const enabledRegions = getEnabledRegions();
+
+// Shared optional `region` option. Defaults to the user's selected region.
+const regionOption = {
+  type: 3, // STRING
+  name: 'region',
+  description: 'Region to use. Defaults to your selected region.',
+  required: false,
+  choices: enabledRegions.map(r => ({ name: REGION_LABELS[r] ?? r, value: r })),
+};
+
 // Define the commands to register
 const commands = [
   {
@@ -15,57 +40,37 @@ const commands = [
   },
   {
     name: 'profile',
-    description: 'Show your latest maimai rating (International region)',
-  },
-  {
-    name: 'profilejp',
-    description: 'Show your latest maimai rating (Japan region)',
+    description: 'Show your latest maimai rating',
+    options: [regionOption],
   },
   {
     name: 'fetch',
-    description: 'Refetch and update your latest maimai scores (International region)',
-  },
-  {
-    name: 'fetchjp',
-    description: 'Refetch and update your latest maimai scores (Japan region)',
+    description: 'Refetch and update your latest maimai scores',
+    options: [regionOption],
   },
   {
     name: 'recents',
-    description: 'Show your most recent play (International region)',
-  },
-  {
-    name: 'recentsjp',
-    description: 'Show your most recent play (Japan region)',
+    description: 'Show your most recent play',
+    options: [regionOption],
   },
   {
     name: 'recommend',
-    description: 'Show song recommendations to improve your rating (International region)',
-  },
-  {
-    name: 'recommendjp',
-    description: 'Show song recommendations to improve your rating (Japan region)',
+    description: 'Show song recommendations to improve your rating',
+    options: [regionOption],
   },
   {
     name: 'daily',
-    description: 'Show your plays from a single JST day (International region)',
-    options: [{
-      type: 3,
-      name: 'date',
-      description: 'JST day (YYYY-MM-DD). Defaults to the day of your most recent play.',
-      required: false,
-      autocomplete: true,
-    }],
-  },
-  {
-    name: 'dailyjp',
-    description: 'Show your plays from a single JST day (Japan region)',
-    options: [{
-      type: 3,
-      name: 'date',
-      description: 'JST day (YYYY-MM-DD). Defaults to the day of your most recent play.',
-      required: false,
-      autocomplete: true,
-    }],
+    description: 'Show your plays from a single JST day',
+    options: [
+      regionOption,
+      {
+        type: 3,
+        name: 'date',
+        description: 'JST day (YYYY-MM-DD). Defaults to the day of your most recent play.',
+        required: false,
+        autocomplete: true,
+      },
+    ],
   },
 ];
 
@@ -77,6 +82,7 @@ async function registerCommands() {
   }
 
   try {
+    console.log(`🌏 Region choices: ${enabledRegions.join(', ')}${process.env.NEXT_PUBLIC_ENABLED_REGIONS ? '' : ' (default — NEXT_PUBLIC_ENABLED_REGIONS not set)'}`);
     console.log('🔄 Registering Discord slash commands...');
 
     const response = await fetch(

--- a/apps/main/src/lib/discord/commands.ts
+++ b/apps/main/src/lib/discord/commands.ts
@@ -6,10 +6,12 @@ import { handleRecommendCommand } from './commands/recommend';
 import { handleAlbumPreferenceSelection } from './commands/album-preference';
 import { handleDailyCommand, handleDailyAutocomplete } from './commands/daily';
 import { createUnknownCommandResponse, DiscordResponse } from './responses';
+import type { Region } from '@/lib/types';
 
 type CommandOption = { name: string; value?: string; type: number; focused?: boolean };
 
-// Command definitions
+// Command definitions. Each data command defaults to the user's selected
+// region and accepts an optional `region` option to override it.
 export const COMMANDS = {
   INVITE: {
     name: 'invite',
@@ -17,45 +19,30 @@ export const COMMANDS = {
   },
   PROFILE: {
     name: 'profile',
-    description: 'Show your latest maimai rating (International region)',
-  },
-  PROFILEJP: {
-    name: 'profilejp',
-    description: 'Show your latest maimai rating (Japan region)',
+    description: 'Show your latest maimai rating',
   },
   FETCH: {
     name: 'fetch',
-    description: 'Refetch and update your latest maimai scores (International region)',
-  },
-  FETCHJP: {
-    name: 'fetchjp',
-    description: 'Refetch and update your latest maimai scores (Japan region)',
+    description: 'Refetch and update your latest maimai scores',
   },
   RECENTS: {
     name: 'recents',
-    description: 'Show your most recent play (International region)',
-  },
-  RECENTSJP: {
-    name: 'recentsjp',
-    description: 'Show your most recent play (Japan region)',
+    description: 'Show your most recent play',
   },
   RECOMMEND: {
     name: 'recommend',
-    description: 'Show song recommendations to improve your rating (International region)',
-  },
-  RECOMMENDJP: {
-    name: 'recommendjp',
-    description: 'Show song recommendations to improve your rating (Japan region)',
+    description: 'Show song recommendations to improve your rating',
   },
   DAILY: {
     name: 'daily',
-    description: 'Show your plays from a single JST day (International region)',
-  },
-  DAILYJP: {
-    name: 'dailyjp',
-    description: 'Show your plays from a single JST day (Japan region)',
+    description: 'Show your plays from a single JST day',
   },
 } as const;
+
+function getRegionParam(options?: CommandOption[]): string | undefined {
+  const value = options?.find(o => o.name === 'region')?.value;
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
 
 export interface CommandContext {
   commandName: string;
@@ -81,72 +68,64 @@ export interface AutocompleteContext {
 export async function handleCommand(context: CommandContext): Promise<DiscordResponse> {
   const { commandName, options, discordUserId, applicationId, interactionToken } = context;
 
+  const regionParam = getRegionParam(options);
+
   switch (commandName.toLowerCase()) {
     case COMMANDS.PROFILE.name.toLowerCase():
-    case COMMANDS.PROFILEJP.name.toLowerCase():
       if (!discordUserId) {
         return createUnknownCommandResponse();
       }
-      const region = commandName.toLowerCase() === 'profilejp' ? 'jp' : 'intl';
       return handleProfileCommand({
         discordUserId,
-        region,
+        regionParam,
         applicationId,
         interactionToken
       });
 
     case COMMANDS.FETCH.name.toLowerCase():
-    case COMMANDS.FETCHJP.name.toLowerCase():
       if (!discordUserId) {
         return createUnknownCommandResponse();
       }
-      const fetchRegion = commandName.toLowerCase() === 'fetchjp' ? 'jp' : 'intl';
       return handleFetchCommand({
         discordUserId,
-        region: fetchRegion,
+        regionParam,
         applicationId,
         interactionToken
       });
 
     case COMMANDS.RECENTS.name.toLowerCase():
-    case COMMANDS.RECENTSJP.name.toLowerCase():
       if (!discordUserId) {
         return createUnknownCommandResponse();
       }
-      const recentsRegion = commandName.toLowerCase() === 'recentsjp' ? 'jp' : 'intl';
       return handleRecentsCommand({
         discordUserId,
-        region: recentsRegion,
+        regionParam,
         applicationId,
         interactionToken
       });
 
     case COMMANDS.RECOMMEND.name.toLowerCase():
-    case COMMANDS.RECOMMENDJP.name.toLowerCase():
       if (!discordUserId) {
         return createUnknownCommandResponse();
       }
-      const recommendRegion = commandName.toLowerCase() === 'recommendjp' ? 'jp' : 'intl';
       return handleRecommendCommand({
         discordUserId,
-        region: recommendRegion,
+        regionParam,
         applicationId,
         interactionToken
       });
 
     case COMMANDS.DAILY.name.toLowerCase():
-    case COMMANDS.DAILYJP.name.toLowerCase():
       if (!discordUserId) {
         return createUnknownCommandResponse();
       }
-      const dailyRegion = commandName.toLowerCase() === 'dailyjp' ? 'jp' : 'intl';
       const dateOption = options?.find(o => o.name === 'date');
       const day = typeof dateOption?.value === 'string' && dateOption.value.length > 0
         ? dateOption.value
         : undefined;
       return handleDailyCommand({
         discordUserId,
-        region: dailyRegion,
+        regionParam,
         day,
         applicationId,
         interactionToken,
@@ -164,12 +143,11 @@ export async function handleAutocomplete(context: AutocompleteContext): Promise<
   const { commandName, options, discordUserId } = context;
 
   switch (commandName.toLowerCase()) {
-    case COMMANDS.DAILY.name.toLowerCase():
-    case COMMANDS.DAILYJP.name.toLowerCase(): {
-      const region = commandName.toLowerCase() === 'dailyjp' ? 'jp' : 'intl';
+    case COMMANDS.DAILY.name.toLowerCase(): {
+      const regionParam = getRegionParam(options);
       const focused = options?.find(o => o.focused) ?? options?.find(o => o.name === 'date');
       const focusedValue = typeof focused?.value === 'string' ? focused.value : '';
-      return handleDailyAutocomplete({ discordUserId, region, focusedValue });
+      return handleDailyAutocomplete({ discordUserId, regionParam, focusedValue });
     }
     default:
       return { type: 8, data: { choices: [] } };
@@ -184,7 +162,7 @@ export async function handleComponents(context: ComponentContext): Promise<Disco
     const parts = customId.split('_');
     if (parts.length === 4) {
       const buttonUserId = parts[1];
-      const region = parts[2] as 'intl' | 'jp';
+      const region = parts[2];
       const skip = parseInt(parts[3], 10);
 
       // verify the user clicking is the same as the user who initiated the command
@@ -194,7 +172,7 @@ export async function handleComponents(context: ComponentContext): Promise<Disco
 
       return handleRecentsCommand({
         discordUserId,
-        region,
+        regionParam: region,
         applicationId,
         interactionToken,
         skip,
@@ -207,7 +185,7 @@ export async function handleComponents(context: ComponentContext): Promise<Disco
     const parts = customId.split('_');
     if (parts.length === 5) {
       const buttonUserId = parts[2];
-      const region = parts[3] as 'intl' | 'jp';
+      const region = parts[3] as Region;
       const choice = parts[4];
 
       // verify the user clicking is the same as the user who initiated the command

--- a/apps/main/src/lib/discord/commands/album-preference.ts
+++ b/apps/main/src/lib/discord/commands/album-preference.ts
@@ -4,10 +4,11 @@ import { and, eq } from 'drizzle-orm';
 import { waitUntil } from '@vercel/functions';
 import { DiscordResponse, editDiscordMessage, DISCORD_COLORS, createDeferredResponse } from '../responses';
 import { handleFetchCommand } from './fetch';
+import type { Region } from '@/lib/types';
 
 export interface AlbumPreferenceOptions {
   discordUserId: string;
-  region: 'intl' | 'jp';
+  region: Region;
   fetchUseAlbums: boolean;
   applicationId: string;
   interactionToken: string;
@@ -83,7 +84,7 @@ export async function handleAlbumPreferenceSelection({
       // Trigger the fetch
       await handleFetchCommand({
         discordUserId,
-        region,
+        regionParam: region,
         applicationId,
         interactionToken,
       });

--- a/apps/main/src/lib/discord/commands/daily.ts
+++ b/apps/main/src/lib/discord/commands/daily.ts
@@ -8,12 +8,13 @@ import {
   createNotRegisteredResponse,
   DiscordResponse,
 } from '../responses';
+import { resolveRegion } from '../region';
 import { generateAndSendDailyPlaysImage } from '../image-utils';
 import { listDailyPlaysAvailableDays } from '@/server/services/daily-plays-data';
 
 async function findDbUserByDiscordId(discordUserId: string) {
   const [dbUser] = await db
-    .select({ id: user.id })
+    .select({ id: user.id, region: user.region })
     .from(user)
     .innerJoin(account, eq(account.userId, user.id))
     .where(and(
@@ -26,7 +27,7 @@ async function findDbUserByDiscordId(discordUserId: string) {
 
 export interface DailyCommandOptions {
   discordUserId: string;
-  region: 'intl' | 'jp';
+  regionParam?: string;
   day?: string;
   applicationId: string;
   interactionToken: string;
@@ -34,7 +35,7 @@ export interface DailyCommandOptions {
 
 export async function handleDailyCommand({
   discordUserId,
-  region,
+  regionParam,
   day,
   applicationId,
   interactionToken,
@@ -48,6 +49,8 @@ export async function handleDailyCommand({
     if (!dbUser) {
       return createNotRegisteredResponse();
     }
+
+    const region = resolveRegion(regionParam, dbUser.region);
 
     const deferredResponse = createDeferredResponse();
 
@@ -73,18 +76,18 @@ export async function handleDailyCommand({
 
 export interface DailyAutocompleteOptions {
   discordUserId?: string;
-  region: 'intl' | 'jp';
+  regionParam?: string;
   focusedValue: string;
 }
 
 /**
- * Autocomplete handler for the `date` option on /daily and /dailyjp.
+ * Autocomplete handler for the `date` option on /daily.
  * Returns up to 25 days the user has plays on, newest first, filtered by
  * whatever the user has typed so far.
  */
 export async function handleDailyAutocomplete({
   discordUserId,
-  region,
+  regionParam,
   focusedValue,
 }: DailyAutocompleteOptions): Promise<DiscordResponse> {
   if (!discordUserId) {
@@ -97,6 +100,7 @@ export async function handleDailyAutocomplete({
       return { type: 8, data: { choices: [] } };
     }
 
+    const region = resolveRegion(regionParam, dbUser.region);
     const days = await listDailyPlaysAvailableDays(dbUser.id, region);
     const filtered = focusedValue
       ? days.filter(d => d.day.includes(focusedValue))

--- a/apps/main/src/lib/discord/commands/fetch.ts
+++ b/apps/main/src/lib/discord/commands/fetch.ts
@@ -1,10 +1,11 @@
 import { db } from '@/lib/db';
 import { getAllStates, parseStatusStates } from '@/lib/fetch-states';
 import { getFetchStatusServer, startFetchServer } from '@/lib/maimai-server-actions';
-import { account, user, userSnapshots } from '@/lib/db/schema-pg';
+import { account, user } from '@/lib/db/schema-pg';
 import { waitUntil } from '@vercel/functions';
-import { and, desc, eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { generateAndSendProfileImage } from '../image-utils';
+import { getProfileSummary, regionDisplayName, resolveRegion } from '../region';
 import { isAlbumSettingsError } from '@/lib/token-errors';
 import { resolveBaseUrl } from '@/lib/base-url';
 import {
@@ -20,12 +21,12 @@ import { Region } from '@/lib/types';
 
 export interface FetchCommandOptions {
   discordUserId: string;
-  region: 'intl' | 'jp';
+  regionParam?: string;
   applicationId: string;
   interactionToken: string;
 }
 
-function createAlbumPreferenceMessage(discordUserId: string, region: 'intl' | 'jp') {
+function createAlbumPreferenceMessage(discordUserId: string, region: Region) {
   return {
     embeds: [{
       title: '⚙️ Album Privacy Settings Required',
@@ -67,12 +68,10 @@ function createAlbumPreferenceMessage(discordUserId: string, region: 'intl' | 'j
 
 export async function handleFetchCommand({
   discordUserId,
-  region,
+  regionParam,
   applicationId,
   interactionToken
 }: FetchCommandOptions): Promise<DiscordResponse> {
-  const regionName = region === 'jp' ? 'Japan' : 'International';
-
   try {
     if (!discordUserId) {
       return createErrorResponse('Unable to identify Discord user. Please try again.');
@@ -84,6 +83,7 @@ export async function handleFetchCommand({
         id: user.id,
         name: user.name,
         username: user.username,
+        region: user.region,
       })
       .from(user)
       .innerJoin(account, eq(account.userId, user.id))
@@ -96,6 +96,9 @@ export async function handleFetchCommand({
     if (!dbUser) {
       return createNotRegisteredResponse();
     }
+
+    const region = resolveRegion(regionParam, dbUser.region);
+    const regionName = regionDisplayName(region);
 
     // Check current time, if it is within 4AM - 7AM in JST, throw an error
     const now = new Date();
@@ -111,7 +114,7 @@ export async function handleFetchCommand({
     const backgroundTask = (async () => {
       try {
         // Start the fetch
-        const startResult = await startFetchServer(dbUser.id, region as Region, undefined, undefined, { skipAfter: true });
+        const startResult = await startFetchServer(dbUser.id, region, undefined, undefined, { skipAfter: true });
 
         // Send initial message
         await editDiscordMessage(applicationId, interactionToken, {
@@ -173,7 +176,7 @@ export async function handleFetchCommand({
 async function pollForUpdates(
   userId: string,
   username: string,
-  region: 'intl' | 'jp',
+  region: Region,
   regionName: string,
   discordUserId: string,
   sessionId: string,
@@ -185,7 +188,7 @@ async function pollForUpdates(
 
   while (attempts < maxAttempts) {
     try {
-      const status = await getFetchStatusServer(userId, region as Region);
+      const status = await getFetchStatusServer(userId, region);
 
       if (status && status.id === sessionId) {
         if (status.status === "completed") {
@@ -248,39 +251,24 @@ async function pollForUpdates(
 async function handleFetchCompleted(
   userId: string,
   username: string,
-  region: 'intl' | 'jp',
+  region: Region,
   regionName: string,
   discordUserId: string,
   applicationId: string,
   interactionToken: string
 ): Promise<void> {
-  // Get the updated snapshot data
-  const [latestSnapshot] = await db
-    .select({
-      publicId: userSnapshots.publicId,
-      rating: userSnapshots.rating,
-      stars: userSnapshots.stars,
-      totalPlayCount: userSnapshots.totalPlayCount,
-      fetchedAt: userSnapshots.fetchedAt,
-    })
-    .from(userSnapshots)
-    .where(and(
-      eq(userSnapshots.userId, userId),
-      eq(userSnapshots.region, region)
-    ))
-    .orderBy(desc(userSnapshots.fetchedAt))
-    .limit(1);
+  // Get the updated snapshot data with new/old chart rating breakdown
+  const summary = await getProfileSummary(userId, region);
 
-  if (latestSnapshot) {
+  if (summary) {
     // Generate and send the profile image using the shared utility
     await new Promise(resolve => setTimeout(resolve, 500));
     await generateAndSendProfileImage({
-      snapshot: latestSnapshot,
+      summary,
       discordUserId,
       regionName,
       applicationId,
       interactionToken,
-      title: `✅ ${regionName} Data Updated`,
       username,
       showGeneratingStatus: true,
     });
@@ -301,7 +289,7 @@ async function handleFetchCompleted(
 
 async function updateFetchProgress(
   statusStates: string,
-  region: 'intl' | 'jp',
+  region: Region,
   regionName: string,
   discordUserId: string,
   applicationId: string,

--- a/apps/main/src/lib/discord/commands/profile.ts
+++ b/apps/main/src/lib/discord/commands/profile.ts
@@ -106,7 +106,7 @@ export async function handleProfileCommand({
         console.error('Error generating profile image:', error);
         // Fallback to text-only roast
         await editDiscordMessage(applicationId, interactionToken, {
-          content: formatProfileSummaryContent(discordUserId, summary),
+          content: formatProfileSummaryContent(discordUserId, summary, regionName),
           embeds: [],
         });
       }

--- a/apps/main/src/lib/discord/commands/profile.ts
+++ b/apps/main/src/lib/discord/commands/profile.ts
@@ -1,8 +1,14 @@
 import { db } from '@/lib/db';
-import { account, user, userSnapshots } from '@/lib/db/schema-pg';
+import { account, user } from '@/lib/db/schema-pg';
 import { waitUntil } from '@vercel/functions';
-import { and, desc, eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { generateAndSendProfileImage } from '../image-utils';
+import {
+  formatProfileSummaryContent,
+  getProfileSummary,
+  regionDisplayName,
+  resolveRegion,
+} from '../region';
 import {
   createDeferredResponse,
   createErrorResponse,
@@ -11,24 +17,21 @@ import {
   DISCORD_COLORS,
   DiscordResponse,
   editDiscordMessage,
-  getRatingComment
 } from '../responses';
 
 export interface ProfileCommandOptions {
   discordUserId: string;
-  region: 'intl' | 'jp';
+  regionParam?: string;
   applicationId: string;
   interactionToken: string;
 }
 
 export async function handleProfileCommand({
   discordUserId,
-  region,
+  regionParam,
   applicationId,
   interactionToken
 }: ProfileCommandOptions): Promise<DiscordResponse> {
-  const regionName = region === 'jp' ? 'Japan' : 'International';
-
   try {
     if (!discordUserId) {
       return createErrorResponse('Unable to identify Discord user. Please try again.');
@@ -40,6 +43,7 @@ export async function handleProfileCommand({
         id: user.id,
         name: user.name,
         username: user.username,
+        region: user.region,
       })
       .from(user)
       .innerJoin(account, eq(account.userId, user.id))
@@ -53,95 +57,57 @@ export async function handleProfileCommand({
       return createNotRegisteredResponse();
     }
 
-    // Get latest snapshot for the region
-    const [latestSnapshot] = await db
-      .select({
-        publicId: userSnapshots.publicId,
-        rating: userSnapshots.rating,
-        stars: userSnapshots.stars,
-        totalPlayCount: userSnapshots.totalPlayCount,
-        fetchedAt: userSnapshots.fetchedAt,
-      })
-      .from(userSnapshots)
-      .where(and(
-        eq(userSnapshots.userId, dbUser.id),
-        eq(userSnapshots.region, region)
-      ))
-      .orderBy(desc(userSnapshots.fetchedAt))
-      .limit(1);
-
-    if (!latestSnapshot) {
-      return createNoDataResponse(regionName);
-    }
+    const region = resolveRegion(regionParam, dbUser.region);
+    const regionName = regionDisplayName(region);
 
     // Defer the response since image generation can take a moment
     const deferredResponse = createDeferredResponse();
 
-    // Generate and send profile image in the background
+    // Generate and send profile in the background
     const backgroundTask = (async () => {
-      try {
-        // Send initial loading message
-        await editDiscordMessage(applicationId, interactionToken, {
-          embeds: [{
-            title: `🔄 Loading ${regionName} Profile`,
-            description: `<@${discordUserId}> Generating your profile image...`,
-            color: DISCORD_COLORS.BLURPLE,
-            fields: [{
-              name: '📊 Status',
-              value: '⏳ Generating Profile Image',
-              inline: false,
-            }],
-            footer: {
-              text: 'tomomai ともマイ • maimai DX score tracker',
-            },
-            timestamp: new Date().toISOString(),
+      // Send initial loading message
+      await editDiscordMessage(applicationId, interactionToken, {
+        embeds: [{
+          title: `🔄 Loading ${regionName} Profile`,
+          description: `<@${discordUserId}> Generating your profile image...`,
+          color: DISCORD_COLORS.BLURPLE,
+          fields: [{
+            name: '📊 Status',
+            value: '⏳ Generating Profile Image',
+            inline: false,
           }],
-        });
+          footer: {
+            text: 'tomomai ともマイ • maimai DX score tracker',
+          },
+          timestamp: new Date().toISOString(),
+        }],
+      });
 
-        // Generate and send the profile image
+      const summary = await getProfileSummary(dbUser.id, region);
+      if (!summary) {
+        await editDiscordMessage(applicationId, interactionToken, {
+          embeds: [createNoDataResponse(regionName).data!.embeds![0]],
+        });
+        return;
+      }
+
+      try {
+        // Generate and send the profile image with the simple roast text
         await new Promise(resolve => setTimeout(resolve, 500));
         await generateAndSendProfileImage({
-          snapshot: latestSnapshot,
+          summary,
           discordUserId,
           regionName,
           applicationId,
           interactionToken,
-          title: `🎯 ${regionName} Region Rating`,
           username: dbUser.username ?? dbUser.name,
         });
       } catch (error) {
         console.error('Error generating profile image:', error);
-        // Fallback to text-only response
-        const rating = latestSnapshot.rating;
-        const comment = getRatingComment(rating);
-
+        // Fallback to text-only roast
         await editDiscordMessage(applicationId, interactionToken, {
-          embeds: [{
-            title: `🎯 ${regionName} Region Rating`,
-            description: `<@${discordUserId}> ${comment}, you only have **${rating}** rating! 😤`,
-            color: DISCORD_COLORS.BLURPLE,
-            fields: [
-              {
-                name: '⭐ Stars',
-                value: latestSnapshot.stars.toString(),
-                inline: true,
-              },
-              {
-                name: '🎮 Total Plays',
-                value: latestSnapshot.totalPlayCount.toString(),
-                inline: true,
-              },
-              {
-                name: '📅 Last Updated',
-                value: `<t:${Math.floor(latestSnapshot.fetchedAt.getTime() / 1000)}:R>`,
-                inline: true,
-              },
-            ],
-            footer: {
-              text: 'tomomai ともマイ • maimai DX score tracker',
-            },
-            timestamp: new Date().toISOString(),
-          }],
+          content: formatProfileSummaryContent(discordUserId, summary),
+          embeds: [],
         });
       }
     })();

--- a/apps/main/src/lib/discord/commands/recents.ts
+++ b/apps/main/src/lib/discord/commands/recents.ts
@@ -8,11 +8,12 @@ import {
   createNotRegisteredResponse,
   DiscordResponse,
 } from '../responses';
+import { resolveRegion } from '../region';
 import { generateAndSendCreditImage } from '../image-utils';
 
 export interface RecentsCommandOptions {
   discordUserId: string;
-  region: 'intl' | 'jp';
+  regionParam?: string;
   applicationId: string;
   interactionToken: string;
   skip?: number;
@@ -20,7 +21,7 @@ export interface RecentsCommandOptions {
 
 export async function handleRecentsCommand({
   discordUserId,
-  region,
+  regionParam,
   applicationId,
   interactionToken,
   skip = 0,
@@ -36,6 +37,7 @@ export async function handleRecentsCommand({
         id: user.id,
         name: user.name,
         username: user.username,
+        region: user.region,
       })
       .from(user)
       .innerJoin(account, eq(account.userId, user.id))
@@ -48,6 +50,8 @@ export async function handleRecentsCommand({
     if (!dbUser) {
       return createNotRegisteredResponse();
     }
+
+    const region = resolveRegion(regionParam, dbUser.region);
 
     // Defer the response since image generation can take a moment
     const deferredResponse = createDeferredResponse();

--- a/apps/main/src/lib/discord/commands/recommend.ts
+++ b/apps/main/src/lib/discord/commands/recommend.ts
@@ -16,10 +16,11 @@ import {
   DiscordResponse,
   editDiscordMessage,
 } from '../responses';
+import { regionDisplayName, resolveRegion } from '../region';
 
 export interface RecommendCommandOptions {
   discordUserId: string;
-  region: 'intl' | 'jp';
+  regionParam?: string;
   applicationId: string;
   interactionToken: string;
 }
@@ -90,12 +91,10 @@ function buildNoRecommendationsEmbed(regionName: string, discordUserId: string) 
 
 export async function handleRecommendCommand({
   discordUserId,
-  region,
+  regionParam,
   applicationId,
   interactionToken,
 }: RecommendCommandOptions): Promise<DiscordResponse> {
-  const regionName = region === 'jp' ? 'Japan' : 'International';
-
   try {
     if (!discordUserId) {
       return createErrorResponse('Unable to identify Discord user. Please try again.');
@@ -104,6 +103,7 @@ export async function handleRecommendCommand({
     const [dbUser] = await db
       .select({
         id: user.id,
+        region: user.region,
       })
       .from(user)
       .innerJoin(account, eq(account.userId, user.id))
@@ -116,6 +116,9 @@ export async function handleRecommendCommand({
     if (!dbUser) {
       return createNotRegisteredResponse();
     }
+
+    const region = resolveRegion(regionParam, dbUser.region);
+    const regionName = regionDisplayName(region);
 
     const deferredResponse = createDeferredResponse();
 

--- a/apps/main/src/lib/discord/image-utils.ts
+++ b/apps/main/src/lib/discord/image-utils.ts
@@ -2,8 +2,10 @@ import {
   DISCORD_COLORS,
   editDiscordMessage,
   editDiscordMessageWithImage,
-  getRatingComment
+  editDiscordMessageWithImageAndContent,
 } from './responses';
+import { formatProfileSummaryContent, regionDisplayName, type ProfileSummary } from './region';
+import type { Region } from '@/lib/types';
 import { prepareCreditData } from '@/server/services/credit-data';
 import { prepareDailyPlaysData } from '@/server/services/daily-plays-data';
 import { ImageCache, renderDailyPlaysImage, renderLastCreditImage } from '@/lib/render-image';
@@ -14,38 +16,25 @@ import { getRatingImageUrl } from '@/lib/rating-calculator';
 import { getLogoUrl, getTypeBadgeUrl } from '@/lib/utils';
 import { DIFFICULTY_ENUM } from '@/lib/db/types';
 
-export interface SnapshotData {
-  publicId: string;
-  rating: number;
-  stars: number;
-  totalPlayCount: number;
-  fetchedAt: Date;
-}
-
 export interface ImageGenerationOptions {
-  snapshot: SnapshotData;
+  summary: ProfileSummary;
   discordUserId: string;
   regionName: string;
   applicationId: string;
   interactionToken: string;
-  title: string;
   username: string;
   showGeneratingStatus?: boolean;
 }
 
 export async function generateAndSendProfileImage({
-  snapshot,
+  summary,
   discordUserId,
   regionName,
   applicationId,
   interactionToken,
-  title,
   username,
   showGeneratingStatus = false,
 }: ImageGenerationOptions): Promise<void> {
-  const rating = snapshot.rating;
-  const comment = getRatingComment(rating);
-
   // Show image generation status if requested
   if (showGeneratingStatus) {
     await editDiscordMessage(applicationId, interactionToken, {
@@ -72,32 +61,7 @@ export async function generateAndSendProfileImage({
     : 'http://localhost:3000';
   const profileUrl = `${baseUrl}/profile/${username}/`;
 
-  const embedData = {
-    title,
-    description: `<@${discordUserId}> ${comment}, you only have **${rating}** rating! 😤`,
-    color: DISCORD_COLORS.GREEN,
-    fields: [
-      {
-        name: '⭐ Stars',
-        value: snapshot.stars.toString(),
-        inline: true,
-      },
-      {
-        name: '🎮 Total Plays',
-        value: snapshot.totalPlayCount.toString(),
-        inline: true,
-      },
-      {
-        name: '📅 Updated',
-        value: `<t:${Math.floor(snapshot.fetchedAt.getTime() / 1000)}:R>`,
-        inline: true,
-      },
-    ],
-    footer: {
-      text: 'tomomai ともマイ • maimai DX score tracker',
-    },
-    timestamp: new Date().toISOString(),
-  };
+  const content = formatProfileSummaryContent(discordUserId, summary);
 
   const components = [
     {
@@ -115,29 +79,29 @@ export async function generateAndSendProfileImage({
 
   try {
     // Generate the image
-    const imageResponse = await fetch(`${baseUrl}/api/export-image?snapshotId=${snapshot.publicId}`, {
+    const imageResponse = await fetch(`${baseUrl}/api/export-image?snapshotId=${summary.publicId}`, {
       method: 'GET',
     });
 
     if (imageResponse.ok) {
       const imageBuffer = Buffer.from(await imageResponse.arrayBuffer());
-      await editDiscordMessageWithImage(applicationId, interactionToken, embedData, imageBuffer, components);
+      await editDiscordMessageWithImageAndContent(applicationId, interactionToken, content, imageBuffer, components);
     } else {
-      // Fallback to regular message if image generation fails
+      // Fallback to text-only message if image generation fails
       console.error('Failed to generate image:', await imageResponse.text());
-      await editDiscordMessage(applicationId, interactionToken, { embeds: [embedData], components });
+      await editDiscordMessage(applicationId, interactionToken, { content, embeds: [], components });
     }
   } catch (imageError) {
-    // Fallback to regular message if image generation fails
+    // Fallback to text-only message if image generation fails
     console.error('Error generating image:', imageError);
-    await editDiscordMessage(applicationId, interactionToken, { embeds: [embedData], components });
+    await editDiscordMessage(applicationId, interactionToken, { content, embeds: [], components });
   }
 }
 
 export interface CreditImageOptions {
   userId: string;
   discordUserId: string;
-  region: 'intl' | 'jp';
+  region: Region;
   applicationId: string;
   interactionToken: string;
   skip?: number;
@@ -151,7 +115,7 @@ export async function generateAndSendCreditImage({
   interactionToken,
   skip = 0,
 }: CreditImageOptions): Promise<void> {
-  const regionName = region === 'jp' ? 'Japan' : 'International';
+  const regionName = regionDisplayName(region);
 
   try {
     // Show loading message
@@ -350,7 +314,7 @@ export async function generateAndSendCreditImage({
 export interface DailyPlaysImageOptions {
   userId: string;
   discordUserId: string;
-  region: 'intl' | 'jp';
+  region: Region;
   day?: string;
   applicationId: string;
   interactionToken: string;
@@ -382,7 +346,7 @@ export async function generateAndSendDailyPlaysImage({
   applicationId,
   interactionToken,
 }: DailyPlaysImageOptions): Promise<void> {
-  const regionName = region === 'jp' ? 'Japan' : 'International';
+  const regionName = regionDisplayName(region);
 
   try {
     const result = await prepareDailyPlaysData(userId, region, day);

--- a/apps/main/src/lib/discord/image-utils.ts
+++ b/apps/main/src/lib/discord/image-utils.ts
@@ -1,7 +1,6 @@
 import {
   DISCORD_COLORS,
   editDiscordMessage,
-  editDiscordMessageWithImage,
   editDiscordMessageWithImageAndContent,
 } from './responses';
 import { formatProfileSummaryContent, regionDisplayName, type ProfileSummary } from './region';
@@ -61,7 +60,7 @@ export async function generateAndSendProfileImage({
     : 'http://localhost:3000';
   const profileUrl = `${baseUrl}/profile/${username}/`;
 
-  const content = formatProfileSummaryContent(discordUserId, summary);
+  const content = formatProfileSummaryContent(discordUserId, summary, regionName);
 
   const components = [
     {
@@ -241,28 +240,9 @@ export async function generateAndSendCreditImage({
     const canvas = await renderLastCreditImage(credit, snapshot, region, cache);
     const imageBuffer = Buffer.from(await canvas.toBuffer('jpg', { density: 2, quality: 0.9 }));
 
-    // Create embed data
-    const embedData = {
-      title: `🎵 ${regionName} Recent Plays`,
-      description: `<@${discordUserId}> Here are your recent plays!`,
-      color: DISCORD_COLORS.BLURPLE,
-      fields: [
-        {
-          name: '📅 Played At',
-          value: `<t:${Math.floor(credit.playedAt.getTime() / 1000)}:R>`,
-          inline: true,
-        },
-        {
-          name: '🎮 Tracks',
-          value: credit.tracks.length.toString(),
-          inline: true,
-        },
-      ],
-      footer: {
-        text: 'tomomai ともマイ • maimai DX score tracker',
-      },
-      timestamp: new Date().toISOString(),
-    };
+    // Plain content line, mirroring /profile and /daily styling
+    const playedUnix = Math.floor(credit.playedAt.getTime() / 1000);
+    const content = `<@${discordUserId}> Here are your recent plays at <t:${playedUnix}:f> (${regionName})`;
 
     // Create navigation buttons
     const components = [
@@ -293,8 +273,15 @@ export async function generateAndSendCreditImage({
       },
     ];
 
-    // Send the image
-    await editDiscordMessageWithImage(applicationId, interactionToken, embedData, imageBuffer, components);
+    // Send the image with plain content (no embed)
+    await editDiscordMessageWithImageOnly(
+      applicationId,
+      interactionToken,
+      content,
+      imageBuffer,
+      `maimai-recent-${region}.jpg`,
+      components,
+    );
 
   } catch (error) {
     console.error('Error generating credit image:', error);
@@ -326,11 +313,16 @@ async function editDiscordMessageWithImageOnly(
   content: string,
   imageBuffer: Buffer,
   filename: string,
+  components?: any[],
 ): Promise<void> {
   const formData = new FormData();
   const blob = new Blob([new Uint8Array(imageBuffer)], { type: 'image/jpeg' });
   formData.append('files[0]', blob, filename);
-  formData.append('payload_json', JSON.stringify({ content, embeds: [] }));
+  const payload: any = { content, embeds: [] };
+  if (components) {
+    payload.components = components;
+  }
+  formData.append('payload_json', JSON.stringify(payload));
 
   await fetch(
     `https://discord.com/api/v10/webhooks/${applicationId}/${interactionToken}/messages/@original`,

--- a/apps/main/src/lib/discord/index.ts
+++ b/apps/main/src/lib/discord/index.ts
@@ -28,4 +28,8 @@ export type { DailyCommandOptions, DailyAutocompleteOptions } from './commands/d
 
 // Image generation utilities
 export { generateAndSendProfileImage, generateAndSendCreditImage, generateAndSendDailyPlaysImage } from './image-utils';
-export type { ImageGenerationOptions, SnapshotData, CreditImageOptions, DailyPlaysImageOptions } from './image-utils';
+export type { ImageGenerationOptions, CreditImageOptions, DailyPlaysImageOptions } from './image-utils';
+
+// Region helpers
+export { regionDisplayName, resolveRegion, getProfileSummary, formatProfileSummaryContent } from './region';
+export type { ProfileSummary } from './region';

--- a/apps/main/src/lib/discord/region.ts
+++ b/apps/main/src/lib/discord/region.ts
@@ -35,7 +35,9 @@ export interface ProfileSummary {
   publicId: string;
   rating: number;
   newRating: number;
+  newCount: number;
   oldRating: number;
+  oldCount: number;
   stars: number;
   totalPlayCount: number;
   fetchedAt: Date;
@@ -58,7 +60,9 @@ export async function getProfileSummary(userId: string, region: Region): Promise
     publicId: snapshot.publicId,
     rating: snapshot.rating,
     newRating,
+    newCount: newSongsB15.length,
     oldRating,
+    oldCount: oldSongsB35.length,
     stars: snapshot.stars,
     totalPlayCount: snapshot.totalPlayCount,
     fetchedAt: snapshot.fetchedAt,
@@ -68,13 +72,20 @@ export async function getProfileSummary(userId: string, region: Region): Promise
 /**
  * Build the simple two-line roast text used by /profile and /fetch:
  *
- *   <@user> {comment}, you only have **{rating}** rating! 😤
- *   -# New Charts: {b15} - Old Charts: {b35} - Stars: {stars} - Total Plays: {plays}
+ *   <@user> {comment}, you only have **{rating}** rating! 😤 (Region)
+ *   -# New Charts: {b15} (avg: {b15avg}) - Old Charts: {b35} (avg: {b35avg}) - Stars: {stars} - Total Plays: {plays}
  */
-export function formatProfileSummaryContent(discordUserId: string, summary: ProfileSummary): string {
+export function formatProfileSummaryContent(
+  discordUserId: string,
+  summary: ProfileSummary,
+  regionName?: string
+): string {
   const comment = getRatingComment(summary.rating);
+  const newAvg = summary.newCount > 0 ? (summary.newRating / summary.newCount).toFixed(1) : '0.0';
+  const oldAvg = summary.oldCount > 0 ? (summary.oldRating / summary.oldCount).toFixed(1) : '0.0';
+  const regionSuffix = regionName ? ` (${regionName})` : '';
   return (
-    `<@${discordUserId}> ${comment}, you only have **${summary.rating}** rating! 😤\n` +
-    `-# New Charts: ${summary.newRating} - Old Charts: ${summary.oldRating} - Stars: ${summary.stars} - Total Plays: ${summary.totalPlayCount}`
+    `<@${discordUserId}> ${comment}, you only have **${summary.rating}** rating! 😤${regionSuffix}\n` +
+    `-# New Charts: ${summary.newRating} (avg: ${newAvg}) - Old Charts: ${summary.oldRating} (avg: ${oldAvg}) - Stars: ${summary.stars} - Total Plays: ${summary.totalPlayCount}`
   );
 }

--- a/apps/main/src/lib/discord/region.ts
+++ b/apps/main/src/lib/discord/region.ts
@@ -1,0 +1,80 @@
+import { getEnabledRegions } from '@/lib/enabled-regions';
+import { splitSongs } from '@/lib/rating-calculator';
+import type { Region, SongWithScore } from '@/lib/types';
+import { fetchLatestSnapshotData } from '@/server/queries/snapshots';
+import { getRatingComment } from './responses';
+
+const REGION_NAMES: Record<Region, string> = {
+  intl: 'International',
+  jp: 'Japan',
+  cn: 'China',
+};
+
+export function regionDisplayName(region: Region): string {
+  return REGION_NAMES[region] ?? region;
+}
+
+/**
+ * Resolve which region a command should operate on.
+ *
+ * Priority: an explicit param (if it names an enabled region) > the user's
+ * selected region from the DB (if enabled) > intl > the first enabled region.
+ */
+export function resolveRegion(
+  param: string | null | undefined,
+  userRegion: Region | null | undefined
+): Region {
+  const enabled = getEnabledRegions();
+  if (param && enabled.includes(param as Region)) return param as Region;
+  if (userRegion && enabled.includes(userRegion)) return userRegion;
+  if (enabled.includes('intl')) return 'intl';
+  return enabled[0];
+}
+
+export interface ProfileSummary {
+  publicId: string;
+  rating: number;
+  newRating: number;
+  oldRating: number;
+  stars: number;
+  totalPlayCount: number;
+  fetchedAt: Date;
+}
+
+/**
+ * Load the latest snapshot for a user/region and compute the new-charts (B15)
+ * and old-charts (B35) rating totals alongside the stored summary fields.
+ */
+export async function getProfileSummary(userId: string, region: Region): Promise<ProfileSummary | null> {
+  const data = await fetchLatestSnapshotData(userId, region);
+  if (!data) return null;
+
+  const { snapshot, songs } = data;
+  const { newSongsB15, oldSongsB35 } = splitSongs(songs as SongWithScore[], snapshot.gameVersion);
+  const newRating = newSongsB15.reduce((sum, s) => sum + s.rating, 0);
+  const oldRating = oldSongsB35.reduce((sum, s) => sum + s.rating, 0);
+
+  return {
+    publicId: snapshot.publicId,
+    rating: snapshot.rating,
+    newRating,
+    oldRating,
+    stars: snapshot.stars,
+    totalPlayCount: snapshot.totalPlayCount,
+    fetchedAt: snapshot.fetchedAt,
+  };
+}
+
+/**
+ * Build the simple two-line roast text used by /profile and /fetch:
+ *
+ *   <@user> {comment}, you only have **{rating}** rating! 😤
+ *   -# New Charts: {b15} - Old Charts: {b35} - Stars: {stars} - Total Plays: {plays}
+ */
+export function formatProfileSummaryContent(discordUserId: string, summary: ProfileSummary): string {
+  const comment = getRatingComment(summary.rating);
+  return (
+    `<@${discordUserId}> ${comment}, you only have **${summary.rating}** rating! 😤\n` +
+    `-# New Charts: ${summary.newRating} - Old Charts: ${summary.oldRating} - Stars: ${summary.stars} - Total Plays: ${summary.totalPlayCount}`
+  );
+}

--- a/apps/main/src/lib/discord/responses.ts
+++ b/apps/main/src/lib/discord/responses.ts
@@ -248,6 +248,36 @@ export async function editDiscordMessage(
   );
 }
 
+// Helper function to edit a Discord message with plain text content + an image
+// attachment (no embed), optionally with components.
+export async function editDiscordMessageWithImageAndContent(
+  applicationId: string,
+  interactionToken: string,
+  content: string,
+  imageBuffer: Buffer,
+  components?: any[]
+): Promise<void> {
+  const formData = new FormData();
+
+  const blob = new Blob([new Uint8Array(imageBuffer)], { type: 'image/png' });
+  formData.append('files[0]', blob, 'maimai-profile.png');
+
+  const payload: any = { content, embeds: [] };
+  if (components) {
+    payload.components = components;
+  }
+
+  formData.append('payload_json', JSON.stringify(payload));
+
+  await fetch(
+    `https://discord.com/api/v10/webhooks/${applicationId}/${interactionToken}/messages/@original`,
+    {
+      method: 'PATCH',
+      body: formData,
+    }
+  );
+}
+
 // Helper function to edit Discord message with image attachment
 export async function editDiscordMessageWithImage(
   applicationId: string,

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dev": "pnpm --filter @tomomai/site dev",
     "build": "pnpm --filter @tomomai/site build",
     "start": "pnpm --filter @tomomai/site start",
+    "tunnel": "cloudflared tunnel run --url http://localhost:3000 tomomai",
     "lint": "pnpm -r lint",
     "typecheck": "pnpm -r typecheck",
     "test": "pnpm --filter @tomomai/site test",


### PR DESCRIPTION
## Summary
- Merge the per-region Discord command pairs into single commands: `/fetch`+`/fetchjp`, `/profile`+`/profilejp`, `/recents`+`/recentsjp`, `/recommend`+`/recommendjp`, `/daily`+`/dailyjp` → just `/fetch`, `/profile`, `/recents`, `/recommend`, `/daily`.
- Each data command now **defaults to the user's selected region** (`user.region`) and accepts an optional `region` option whose choices are gated by `getEnabledRegions()` — adding `cn` support throughout the Discord module (types widened from `'intl' | 'jp'` to `Region`).
- Region resolution priority: explicit param (if enabled) → user's selected region (if enabled) → `intl` → first enabled region.
- **Simplify `/fetch` and `/profile` output** to plain text (no embed), matching the `/daily` style:

  ```
  <@user> finally past the tutorial, only took you this long, you only have 15024 rating! 😤
  -# New Charts: 4425 - Old Charts: 10417 - Stars: 12 - Total Plays: 123
  ```

  New/Old chart ratings are the B15/B35 sums computed via `splitSongs()`. The rendered profile image is still attached below the text; `/fetch` in-progress and error messages remain embeds (only the final message was simplified).

## Notes
- New helper module `lib/discord/region.ts`: `resolveRegion`, `regionDisplayName`, `getProfileSummary`, `formatProfileSummaryContent`.
- The registration script now builds the `region` option choices from `NEXT_PUBLIC_ENABLED_REGIONS` (defaults to `intl,jp`) and logs which regions it registers. **Commands must be re-registered** (`node scripts/register-discord-commands.js`) for the old `*jp` commands to disappear and the `region` option to appear. To register `cn`, set `NEXT_PUBLIC_ENABLED_REGIONS` in `.env.local` before running.

## Testing
- `pnpm typecheck` — clean
- `pnpm exec eslint src/lib/discord/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Discord commands now accept an optional region parameter instead of separate region-specific variants, allowing users to override their stored region preference per command.

* **Refactor**
  * Consolidated separate JP and International command variants into unified commands with dynamic region selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->