### PR TITLE
feat(main/ui): MD3 tonal surfaces, glass overlays, and pill controls

### DIFF
--- a/apps/main/src/components/animate-ui/components/radix/hover-card.tsx
+++ b/apps/main/src/components/animate-ui/components/radix/hover-card.tsx
@@ -37,7 +37,7 @@ function HoverCardContent({
         align={align}
         sideOffset={sideOffset}
         className={cn(
-          'bg-popover text-popover-foreground z-50 w-64 origin-(--radix-hover-card-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden',
+          'glass-strong text-popover-foreground z-50 w-64 origin-(--radix-hover-card-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden',
           className,
         )}
         {...props}

--- a/apps/main/src/components/consent-dialog.tsx
+++ b/apps/main/src/components/consent-dialog.tsx
@@ -12,7 +12,7 @@ import {
 import { Checkbox } from "@/components/animate-ui/components/radix/checkbox";
 import { Button } from "@tomomai/ui";
 import { PolicyDialog } from "@/components/policy-dialog";
-import { ChevronDown, ChevronUp, Dot, Loader2 } from "lucide-react";
+import { Dot, Loader2 } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useLocale } from "./providers/locale-provider";
 import { isCNExclusive, isRegionEnabled } from "@/lib/enabled-regions";
@@ -44,8 +44,6 @@ export function ConsentDialog({
   const [privacyChecked, setPrivacyChecked] = useState(false);
   const [showTosDialog, setShowTosDialog] = useState(false);
   const [showPrivacyDialog, setShowPrivacyDialog] = useState(false);
-  const [showTosPreview, setShowTosPreview] = useState(false);
-  const [showPrivacyPreview, setShowPrivacyPreview] = useState(false);
   const [proceeding, setProceeding] = useState<"discord" | "twitter" | null>(null);
 
   useEffect(() => {
@@ -71,7 +69,7 @@ export function ConsentDialog({
         <ResponsiveDialogContent
           showCloseButton={false}
           className="max-w-2xl max-h-[90dvh]"
-          style={{ backgroundImage: "linear-gradient(160deg, color-mix(in srgb, var(--primary) 10%, transparent), transparent 22%)" }}
+          style={{ backgroundImage: "linear-gradient(160deg, color-mix(in srgb, var(--primary) 18%, transparent), transparent 22%)" }}
           onPointerDownOutside={(e) => e.preventDefault()}
           onEscapeKeyDown={(e) => e.preventDefault()}
         >
@@ -126,65 +124,37 @@ export function ConsentDialog({
 
             {/* Consent checkboxes */}
             <div className="space-y-2">
-              <div className="rounded-xl border border-border overflow-hidden">
-                <div className="flex items-center gap-3 px-3 py-2.5">
-                  <Checkbox
-                    id="tos-consent"
-                    checked={tosChecked}
-                    onCheckedChange={(checked) => setTosChecked(checked === true)}
-                  />
-                  <label
-                    htmlFor="tos-consent"
-                    className="text-sm font-semibold cursor-pointer select-none flex-1"
-                  >
-                    {t("agreeToTos")}
-                  </label>
-                  <Button variant="ghost" size="sm" className="h-7 px-2" onClick={() => setShowTosDialog(true)}>
-                    {t("viewFullText")}
-                  </Button>
-                  <Button variant="ghost" size="icon" className="h-7 w-7" onClick={() => setShowTosPreview(!showTosPreview)}>
-                    {showTosPreview ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
-                  </Button>
-                </div>
-                {showTosPreview && (
-                  <div className="px-3 pb-3">
-                    <div className="p-3 bg-muted/60 rounded-md max-h-50 overflow-y-auto">
-                      <p className="text-xs text-muted-foreground whitespace-pre-wrap line-clamp-8">
-                        {tosContent.substring(0, 1000)}...
-                      </p>
-                    </div>
-                  </div>
-                )}
+              <div className="flex items-center gap-3 px-3 py-2.5 rounded-xl border border-border">
+                <Checkbox
+                  id="tos-consent"
+                  checked={tosChecked}
+                  onCheckedChange={(checked) => setTosChecked(checked === true)}
+                />
+                <label
+                  htmlFor="tos-consent"
+                  className="text-sm font-semibold cursor-pointer select-none flex-1"
+                >
+                  {t("agreeToTos")}
+                </label>
+                <Button variant="ghost" size="sm" className="h-7 px-2" onClick={() => setShowTosDialog(true)}>
+                  {t("viewFullText")}
+                </Button>
               </div>
-              <div className="rounded-xl border border-border overflow-hidden">
-                <div className="flex items-center gap-3 px-3 py-2.5">
-                  <Checkbox
-                    id="privacy-consent"
-                    checked={privacyChecked}
-                    onCheckedChange={(checked) => setPrivacyChecked(checked === true)}
-                  />
-                  <label
-                    htmlFor="privacy-consent"
-                    className="text-sm font-semibold cursor-pointer select-none flex-1"
-                  >
-                    {t("agreeToPrivacy")}
-                  </label>
-                  <Button variant="ghost" size="sm" className="h-7 px-2" onClick={() => setShowPrivacyDialog(true)}>
-                    {t("viewFullText")}
-                  </Button>
-                  <Button variant="ghost" size="icon" className="h-7 w-7" onClick={() => setShowPrivacyPreview(!showPrivacyPreview)}>
-                    {showPrivacyPreview ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
-                  </Button>
-                </div>
-                {showPrivacyPreview && (
-                  <div className="px-3 pb-3">
-                    <div className="p-3 bg-muted/60 rounded-md max-h-32 overflow-y-auto">
-                      <p className="text-xs text-muted-foreground whitespace-pre-wrap line-clamp-6">
-                        {privacyContent.substring(0, 500)}...
-                      </p>
-                    </div>
-                  </div>
-                )}
+              <div className="flex items-center gap-3 px-3 py-2.5 rounded-xl border border-border">
+                <Checkbox
+                  id="privacy-consent"
+                  checked={privacyChecked}
+                  onCheckedChange={(checked) => setPrivacyChecked(checked === true)}
+                />
+                <label
+                  htmlFor="privacy-consent"
+                  className="text-sm font-semibold cursor-pointer select-none flex-1"
+                >
+                  {t("agreeToPrivacy")}
+                </label>
+                <Button variant="ghost" size="sm" className="h-7 px-2" onClick={() => setShowPrivacyDialog(true)}>
+                  {t("viewFullText")}
+                </Button>
               </div>
             </div>
 

--- a/apps/main/src/components/data-banner.tsx
+++ b/apps/main/src/components/data-banner.tsx
@@ -77,11 +77,13 @@ function SnapshotSelector({
       <SelectTrigger className="flex-1 min-w-0 h-10">
         <SelectValue placeholder={t('dataBanner.selectSnapshot')} className="overflow-hidden">
           {selectedSnapshotData ? (
-            <div className="flex flex-col items-start min-w-0 truncate text-xs">
-              <span>{formatDate(selectedSnapshotData.fetchedAt)}</span>
-              <span className="text-2xs text-muted-foreground">
-                {selectedSnapshotData.displayName} • {selectedSnapshotData.rating} rating • {getVersionInfo(selectedSnapshotData.gameVersion)?.shortName || "Unknown"}
-              </span>
+            <div className="flex flex-col items-start min-w-0 gap-0.5">
+              <div className="flex items-center gap-1.5 min-w-0">
+                <span className="truncate text-xs font-medium">{selectedSnapshotData.displayName}</span>
+                <Badge variant="tonal" className="shrink-0 px-1.5 py-0 text-2xs font-medium bg-primary-container/50">{selectedSnapshotData.rating} rating</Badge>
+                <Badge variant="secondary" className="shrink-0 px-1.5 py-0 text-2xs font-normal bg-secondary/50">{getVersionInfo(selectedSnapshotData.gameVersion)?.shortName || "Unknown"}</Badge>
+              </div>
+              <span className="text-2xs text-muted-foreground">{formatDate(selectedSnapshotData.fetchedAt)}</span>
             </div>
           ) : (
             <span>{t('dataBanner.selectSnapshot')}</span>
@@ -91,11 +93,13 @@ function SnapshotSelector({
       <SelectContent>
         {snapshots.map((snapshot) => (
           <SelectItem key={snapshot.id} value={snapshot.id}>
-            <div className="flex flex-col items-start min-w-0 truncate">
-              <span>{formatDate(snapshot.fetchedAt)}</span>
-              <span className="text-xs dark:text-muted-foreground">
-                {snapshot.displayName} • {snapshot.rating} rating • {getVersionInfo(snapshot.gameVersion)?.shortName || "Unknown"}
-              </span>
+            <div className="flex flex-col items-start min-w-0 gap-0.5">
+              <div className="flex items-center gap-1.5 min-w-0">
+                <span className="truncate text-xs font-medium">{snapshot.displayName}</span>
+                <Badge variant="tonal" className="shrink-0 px-1.5 py-0 text-2xs font-medium bg-primary-container/50">{snapshot.rating} rating</Badge>
+                <Badge variant="secondary" className="shrink-0 px-1.5 py-0 text-2xs font-normal bg-secondary/50">{getVersionInfo(snapshot.gameVersion)?.shortName || "Unknown"}</Badge>
+              </div>
+              <span className="text-2xs text-muted-foreground">{formatDate(snapshot.fetchedAt)}</span>
             </div>
           </SelectItem>
         ))}

--- a/apps/main/src/components/public-data-banner.tsx
+++ b/apps/main/src/components/public-data-banner.tsx
@@ -39,11 +39,13 @@ export function PublicDataBanner({
         {/* Left side - Latest snapshot info */}
         <div className="flex items-center space-x-4">
           {snapshotData ? (
-            <div className="flex flex-col items-start">
-              <span className="text-sm font-medium">{t('dataBanner.dataSnapshot')} {snapshotData ? formatDate(snapshotData.fetchedAt) : ''}</span>
-              <h1 className="text-xs text-muted-foreground font-normal">
-                {snapshotData.displayName} • {snapshotData.rating} rating • {getVersionInfo(snapshotData.gameVersion)?.shortName || "Unknown"}
-              </h1>
+            <div className="flex flex-col items-start gap-1.5">
+              <div className="flex items-center gap-2">
+                <h1 className="m-0 text-base font-medium">{snapshotData.displayName}</h1>
+                <Badge variant="tonal" className="font-medium bg-primary-container/50">{snapshotData.rating} rating</Badge>
+                <Badge variant="secondary" className="font-normal bg-secondary/50">{getVersionInfo(snapshotData.gameVersion)?.shortName || "Unknown"}</Badge>
+              </div>
+              <span className="text-xs text-muted-foreground">{t('dataBanner.dataSnapshot')} {snapshotData ? formatDate(snapshotData.fetchedAt) : ''}</span>
             </div>
           ) : (
             <Badge variant="secondary">{t('dataBanner.noDataAvailable')}</Badge>

--- a/packages/ui/src/components/alert-dialog.tsx
+++ b/packages/ui/src/components/alert-dialog.tsx
@@ -46,7 +46,7 @@ function AlertDialogOverlay({
     <AlertDialogPrimitive.Overlay
       data-slot="alert-dialog-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/45",
         className
       )}
       {...props}
@@ -64,7 +64,7 @@ function AlertDialogContent({
       <AlertDialogPrimitive.Content
         data-slot="alert-dialog-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          "glass-strong data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-xl border p-6 shadow-lg duration-200 sm:max-w-lg",
           className
         )}
         {...props}

--- a/packages/ui/src/components/animated-alert-dialog.tsx
+++ b/packages/ui/src/components/animated-alert-dialog.tsx
@@ -67,7 +67,7 @@ function AnimatedAlertDialogOverlay({
     >
       <motion.div
         className={cn(
-          "fixed inset-0 z-50 bg-black/50",
+          "fixed inset-0 z-50 bg-black/45",
           className
         )}
         initial={{ opacity: 0 }}
@@ -101,7 +101,7 @@ function AnimatedAlertDialogContent({
           >
             <motion.div
               className={cn(
-                "bg-background fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] gap-4 rounded-lg border p-6 shadow-lg sm:max-w-lg",
+                "glass-strong fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] gap-4 rounded-xl border p-6 shadow-lg sm:max-w-lg",
                 className
               )}
               initial={{ opacity: 0, scale: 0.85, y: "-45%", x: "-50%" }}

--- a/packages/ui/src/components/animated-dialog.tsx
+++ b/packages/ui/src/components/animated-dialog.tsx
@@ -69,7 +69,7 @@ function AnimatedDialogOverlay({
     >
       <motion.div
         className={cn(
-          "fixed inset-0 z-50 bg-black/50",
+          "fixed inset-0 z-50 bg-black/45",
           className
         )}
         initial={{ opacity: 0 }}
@@ -105,7 +105,7 @@ function AnimatedDialogContent({
       >
         <motion.div
           className={cn(
-            "bg-background fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] gap-4 rounded-lg border p-6 shadow-lg sm:max-w-lg",
+            "glass-strong fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] gap-4 rounded-xl border p-6 shadow-lg sm:max-w-lg",
             className
           )}
           initial={{ opacity: 0, scale: 0.85, y: "-45%", x: "-50%" }}

--- a/packages/ui/src/components/animated-select.tsx
+++ b/packages/ui/src/components/animated-select.tsx
@@ -82,7 +82,7 @@ function AnimatedSelectContent({
       >
         <motion.div
           className={cn(
-            "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md",
+            "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border glass-surface text-popover-foreground shadow-md",
             // transform-origin based on which side content appears
             "data-[side=bottom]:origin-top data-[side=top]:origin-bottom data-[side=left]:origin-right data-[side=right]:origin-left",
             position === "popper" &&

--- a/packages/ui/src/components/badge.tsx
+++ b/packages/ui/src/components/badge.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "../utils"
 
 const badgeVariants = cva(
-  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  "inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 [&_svg]:size-3 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
@@ -12,6 +12,10 @@ const badgeVariants = cva(
           "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
         secondary:
           "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        tonal:
+          "border-transparent bg-primary-container text-on-primary-container hover:bg-primary-container/85",
+        tertiary:
+          "border-transparent bg-tertiary-container text-on-tertiary-container hover:bg-tertiary-container/85",
         destructive:
           "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
         outline: "text-foreground",

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -8,7 +8,7 @@ import { cn } from "../utils"
 import { triggerHaptic } from "../haptics"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-full text-sm font-medium transition-all active:scale-[0.97] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {
@@ -20,14 +20,16 @@ const buttonVariants = cva(
           "border bg-card shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
         secondary:
           "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
+        tonal:
+          "bg-primary-container text-on-primary-container shadow-xs hover:bg-primary-container/85",
         ghost:
           "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",
-        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
-        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+        sm: "h-8 rounded-full gap-1.5 px-3 has-[>svg]:px-2.5",
+        lg: "h-10 rounded-full px-6 has-[>svg]:px-4",
         icon: "size-9",
       },
     },

--- a/packages/ui/src/components/dialog.tsx
+++ b/packages/ui/src/components/dialog.tsx
@@ -47,7 +47,7 @@ function DialogOverlay({
     <DialogPrimitive.Overlay
       data-slot="dialog-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/45",
         className
       )}
       {...props}
@@ -69,7 +69,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          "glass-strong data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-xl border p-6 shadow-lg duration-200 sm:max-w-lg",
           className
         )}
         {...props}

--- a/packages/ui/src/components/drawer.tsx
+++ b/packages/ui/src/components/drawer.tsx
@@ -76,7 +76,7 @@ function DrawerOverlay({
     <DrawerPrimitive.Overlay
       data-slot="drawer-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/45",
         className
       )}
       {...props}
@@ -99,7 +99,7 @@ function DrawerContent({
     <DrawerPrimitive.Content
       data-slot="drawer-content"
       className={cn(
-        "group/drawer-content bg-background fixed z-50 flex h-auto flex-col",
+        "group/drawer-content glass-strong fixed z-50 flex h-auto flex-col",
         "data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:rounded-b-lg data-[vaul-drawer-direction=top]:border-b",
         "data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:rounded-t-lg data-[vaul-drawer-direction=bottom]:border-t",
         "data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:rounded-l-lg data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=right]:sm:max-w-sm",

--- a/packages/ui/src/components/dropdown-menu.tsx
+++ b/packages/ui/src/components/dropdown-menu.tsx
@@ -43,7 +43,7 @@ function DropdownMenuContent({
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md",
+          "glass-surface text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md",
           className
         )}
         {...props}
@@ -80,7 +80,7 @@ function DropdownMenuItem({
         onSelect?.(e)
       }}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-foreground/15 focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
@@ -98,7 +98,7 @@ function DropdownMenuCheckboxItem({
     <DropdownMenuPrimitive.CheckboxItem
       data-slot="dropdown-menu-checkbox-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-foreground/15 focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       checked={checked}
@@ -134,7 +134,7 @@ function DropdownMenuRadioItem({
     <DropdownMenuPrimitive.RadioItem
       data-slot="dropdown-menu-radio-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-foreground/15 focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
@@ -217,7 +217,7 @@ function DropdownMenuSubTrigger({
       data-slot="dropdown-menu-sub-trigger"
       data-inset={inset}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8",
+        "focus:bg-foreground/15 focus:text-accent-foreground data-[state=open]:bg-foreground/15 data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8",
         className
       )}
       {...props}
@@ -236,7 +236,7 @@ function DropdownMenuSubContent({
     <DropdownMenuPrimitive.SubContent
       data-slot="dropdown-menu-sub-content"
       className={cn(
-        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
+        "glass-surface text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
         className
       )}
       {...props}

--- a/packages/ui/src/components/input.tsx
+++ b/packages/ui/src/components/input.tsx
@@ -8,8 +8,8 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-lg border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "focus-visible:border-primary/60 focus-visible:ring-primary/25 focus-visible:ring-[3px]",
         "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
         className
       )}

--- a/packages/ui/src/components/select.tsx
+++ b/packages/ui/src/components/select.tsx
@@ -75,7 +75,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border glass-surface text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         position === "popper" &&
           "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
         className
@@ -118,7 +118,7 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-foreground/15 focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
     {...props}

--- a/packages/ui/src/components/sheet.tsx
+++ b/packages/ui/src/components/sheet.tsx
@@ -47,7 +47,7 @@ function SheetOverlay({
     <SheetPrimitive.Overlay
       data-slot="sheet-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/45",
         className
       )}
       {...props}
@@ -69,7 +69,7 @@ function SheetContent({
       <SheetPrimitive.Content
         data-slot="sheet-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+          "glass-strong data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
           side === "right" &&
           "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
           side === "left" &&

--- a/packages/ui/src/components/sidebar.tsx
+++ b/packages/ui/src/components/sidebar.tsx
@@ -70,12 +70,7 @@ const SidebarItem = React.forwardRef<HTMLButtonElement, SidebarItemProps>(
         {...props}
       >
         {Icon && (
-          <Icon
-            className={cn(
-              "size-4 me-2 transition-all",
-              isActive && "scale-125"
-            )}
-          />
+          <Icon className="size-4 me-2 transition-all" />
         )}
         {text ?? children}
       </button>

--- a/packages/ui/src/components/textarea.tsx
+++ b/packages/ui/src/components/textarea.tsx
@@ -7,7 +7,7 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
     <textarea
       data-slot="textarea"
       className={cn(
-        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "border-input placeholder:text-muted-foreground focus-visible:border-primary/60 focus-visible:ring-primary/25 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-lg border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         className
       )}
       {...props}

--- a/packages/ui/src/components/tooltip.tsx
+++ b/packages/ui/src/components/tooltip.tsx
@@ -20,7 +20,7 @@ const TooltipContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "z-50 overflow-hidden rounded-md border glass-surface px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className
       )}
       {...props}

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -30,10 +30,28 @@
     --color-popover: var(--popover);
     --color-card-foreground: var(--card-foreground);
     --color-card: var(--card);
+    --color-surface: var(--background);
+    --color-surface-container-lowest: var(--surface-container-lowest);
+    --color-surface-container-low: var(--surface-container-low);
+    --color-surface-container: var(--surface-container);
+    --color-surface-container-high: var(--surface-container-high);
+    --color-surface-container-highest: var(--surface-container-highest);
+    --color-primary-container: var(--primary-container);
+    --color-on-primary-container: var(--on-primary-container);
+    --color-secondary-container: var(--secondary-container);
+    --color-on-secondary-container: var(--on-secondary-container);
+    --color-tertiary: var(--tertiary);
+    --color-tertiary-foreground: var(--on-tertiary);
+    --color-tertiary-container: var(--tertiary-container);
+    --color-on-tertiary-container: var(--on-tertiary-container);
+    --color-border-strong: var(--border-strong);
+    --radius-xs: calc(var(--radius) - 14px);
     --radius-sm: calc(var(--radius) - 6px);
     --radius-md: calc(var(--radius) - 3px);
     --radius-lg: var(--radius);
-    --radius-xl: calc(var(--radius) + 6px);
+    --radius-xl: calc(var(--radius) + 8px);
+    --radius-2xl: calc(var(--radius) + 16px);
+    --radius-3xl: calc(var(--radius) + 28px);
     --text-2xs: 0.625rem;
     --breakpoint-2xs: 20rem;
     --breakpoint-xs: 30rem;
@@ -66,6 +84,29 @@
     --border: oklch(0.9 calc(var(--contrast) * 0.01518) var(--hue));
     --input: oklch(0.9 calc(var(--contrast) * 0.01518) var(--hue));
     --ring: oklch(0.7 calc(var(--contrast) * 0.0759) var(--hue));
+
+    /* MD3 tonal surface ladder (light) — elevation rises toward lighter + faint hue tint */
+    --surface-container-lowest: oklch(1 calc(var(--contrast) * 0.002 * var(--saturation)) var(--hue));
+    --surface-container-low: oklch(calc(1 - var(--lightness) * 0.012) calc(var(--contrast) * 0.005 * var(--saturation)) var(--hue));
+    --surface-container: var(--content);
+    --surface-container-high: oklch(calc(1 - var(--lightness) * 0.033) calc(var(--contrast) * 0.009 * var(--saturation)) var(--hue));
+    --surface-container-highest: oklch(calc(1 - var(--lightness) * 0.048) calc(var(--contrast) * 0.012 * var(--saturation)) var(--hue));
+    --border-strong: oklch(0.82 calc(var(--contrast) * 0.025) var(--hue));
+
+    /* Glass fills for floating overlays — light theme: bright translucent */
+    --glass-surface: oklch(0.99 calc(var(--contrast) * 0.004 * var(--saturation)) var(--hue) / 71%);
+    --glass-strong: oklch(0.996 calc(var(--contrast) * 0.004 * var(--saturation)) var(--hue) / 90%);
+
+    /* MD3 container color roles (light) — hue-driven so dynamic color is preserved */
+    --primary-container: oklch(0.92 calc(var(--contrast) * 0.065) var(--hue));
+    --on-primary-container: oklch(0.32 calc(var(--contrast) * 0.13) var(--hue));
+    --secondary-container: oklch(0.93 calc(var(--contrast) * 0.02) var(--hue));
+    --on-secondary-container: oklch(0.34 calc(var(--contrast) * 0.04) var(--hue));
+    --tertiary: oklch(0.55 calc(var(--contrast) * 0.13) calc(var(--hue) + 60));
+    --on-tertiary: oklch(0.99 calc(var(--contrast) * 0.02) calc(var(--hue) + 60));
+    --tertiary-container: oklch(0.92 calc(var(--contrast) * 0.06) calc(var(--hue) + 60));
+    --on-tertiary-container: oklch(0.30 calc(var(--contrast) * 0.11) calc(var(--hue) + 60));
+
     --chart-1: oklch(0.646 0.222 41.116);
     --chart-2: oklch(0.6 0.118 184.704);
     --chart-3: oklch(0.398 0.07 227.392);
@@ -100,9 +141,34 @@
     --accent: var(--secondary);
     --accent-foreground: var(--foreground);
     --destructive: oklch(0.704 0.191 22.216);
-    --border: oklch(1 calc(var(--contrast) * 0.01) var(--hue) / 10%);
+    --border: oklch(1 calc(var(--contrast) * 0.012) var(--hue) / 14%);
     --input: oklch(1 calc(var(--contrast) * 0.01) var(--hue) / 15%);
     --ring: oklch(0.556 calc(var(--contrast) * 0.05) var(--hue));
+
+    /* MD3 tonal surface ladder (dark) — elevation rises toward lighter + stronger hue tint */
+    --surface-container-lowest: oklch(calc(0.10 + var(--lightness) * 0.02) calc(var(--contrast) * 0.012 * var(--saturation)) var(--hue));
+    --surface-container-low: oklch(calc(0.13 + var(--lightness) * 0.04) calc(var(--contrast) * 0.016 * var(--saturation)) var(--hue));
+    --surface-container: var(--content);
+    --surface-container-high: oklch(calc(0.17 + var(--lightness) * 0.065) calc(var(--contrast) * 0.024 * var(--saturation)) var(--hue));
+    --surface-container-highest: oklch(calc(0.20 + var(--lightness) * 0.075) calc(var(--contrast) * 0.028 * var(--saturation)) var(--hue));
+    --border-strong: oklch(1 calc(var(--contrast) * 0.012) var(--hue) / 22%);
+
+    /* Glass fills for floating overlays — dark theme: deep translucent, only a touch
+     * above the page so the panel reads dark like the page, with the border doing
+     * the separation (not a milky light-grey wash). */
+    --glass-surface: oklch(calc(0.15 + var(--lightness) * 0.03) calc(var(--contrast) * 0.016 * var(--saturation)) var(--hue) / 73%);
+    --glass-strong: oklch(calc(0.14 + var(--lightness) * 0.03) calc(var(--contrast) * 0.02 * var(--saturation)) var(--hue) / 80%);
+
+    /* MD3 container color roles (dark) — hue-driven so dynamic color is preserved */
+    --primary-container: oklch(0.36 calc(var(--contrast) * 0.10) var(--hue));
+    --on-primary-container: oklch(0.92 calc(var(--contrast) * 0.06) var(--hue));
+    --secondary-container: oklch(0.32 calc(var(--contrast) * 0.035) var(--hue));
+    --on-secondary-container: oklch(0.92 calc(var(--contrast) * 0.025) var(--hue));
+    --tertiary: oklch(0.82 calc(var(--contrast) * 0.11) calc(var(--hue) + 60));
+    --on-tertiary: oklch(0.24 calc(var(--contrast) * 0.06) calc(var(--hue) + 60));
+    --tertiary-container: oklch(0.37 calc(var(--contrast) * 0.085) calc(var(--hue) + 60));
+    --on-tertiary-container: oklch(0.92 calc(var(--contrast) * 0.05) calc(var(--hue) + 60));
+
     --chart-1: oklch(0.488 0.243 264.376);
     --chart-2: oklch(0.696 0.17 162.48);
     --chart-3: oklch(0.769 0.188 70.08);
@@ -125,5 +191,45 @@
 
     100% {
         background-position: 200% 0;
+    }
+}
+
+/* Glass — floating surfaces that sit ABOVE content. Never use on base cards.
+ * The blur lives on the panel itself, so it aligns exactly and animates with the
+ * panel's own enter/exit. The value is var()-wrapped because Lightning CSS (in
+ * @tailwindcss/postcss) strips concrete backdrop-filter values but keeps var()
+ * ones; without the var() the declaration silently never reaches the browser. */
+@utility glass-surface {
+    background-color: var(--glass-surface);
+    --glass-blur: blur(16px) saturate(150%);
+    -webkit-backdrop-filter: var(--glass-blur);
+    backdrop-filter: var(--glass-blur);
+}
+
+@utility glass-strong {
+    background-color: var(--glass-strong);
+    --glass-blur: blur(24px) saturate(160%);
+    -webkit-backdrop-filter: var(--glass-blur);
+    backdrop-filter: var(--glass-blur);
+}
+
+/* Opaque fallback where backdrop-filter is unsupported, so overlays stay legible. */
+@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+
+    .glass-surface,
+    .glass-strong {
+        background-color: var(--surface-container-high);
+    }
+}
+
+@layer base {
+    body {
+        /* Inter stylistic sets for a cleaner, more modern glyph set; tabular figures
+         * so the rating / score numbers that fill this app line up like a readout. */
+        font-feature-settings: "cv02", "cv03", "cv04", "cv11", "ss03";
+        font-variant-numeric: tabular-nums;
+        font-optical-sizing: auto;
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
     }
 }


### PR DESCRIPTION
Add a Material 3 tonal surface ladder and container color roles to the theme, glass-surface/glass-strong utilities for floating overlays, and Inter stylistic sets with tabular numerics. Round buttons and badges to pills, add tonal/tertiary variants, and badge-ify the rating/version in the data banners.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced glass morphism effects for modals, dialogs, and dropdown menus
  * Added new badge and button style variants (tonal, tertiary options)
  * Expanded design system with new color tokens and theme roles

* **Style**
  * Lightened modal overlay backgrounds for improved visual clarity
  * Refined button corner radius and updated input focus states
  * Restructured snapshot and consent dialog information display layouts
  * Simplified sidebar icon styling and animations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->