### PR TITLE
fix(main/image): migrate maimaidx.jp covers to R2 to cut Vercel transforms

### DIFF
--- a/apps/main/scripts/migrate-covers-to-r2.mjs
+++ b/apps/main/scripts/migrate-covers-to-r2.mjs
@@ -1,0 +1,125 @@
+// One-shot migration: rewrite maimaidx Music cover URLs in the prod `songs`
+// table to their pre-optimized R2 webp equivalents, uploading any missing webps
+// first. Read-only unless invoked with --apply.
+//
+//   node scripts/migrate-covers-to-r2.mjs          # dry run (no writes)
+//   node scripts/migrate-covers-to-r2.mjs --apply   # upload missing + rewrite DB
+import fs from "node:fs";
+import postgres from "postgres";
+import sharp from "sharp";
+import { Agent } from "undici";
+import { S3Client, ListObjectsV2Command, PutObjectCommand } from "@aws-sdk/client-s3";
+
+const APPLY = process.argv.includes("--apply");
+
+const env = fs.readFileSync(new URL("../.env.local", import.meta.url), "utf8");
+const get = (k) => {
+  const m = env.match(new RegExp(`^${k}\\s*=\\s*["']?([^"'\\n]+)["']?\\s*$`, "m"));
+  return m ? m[1] : undefined;
+};
+
+const R2_BASE = get("NEXT_PUBLIC_R2_URL"); // https://cdn.tomomai.lol
+const BUCKET = get("R2_BUCKET");
+const agent = new Agent({ connect: { rejectUnauthorized: false } });
+
+const sql = postgres(get("POSTGRES_URL_PROD"), { ssl: "require", max: 1 });
+const r2 = new S3Client({
+  region: "auto",
+  endpoint: get("R2_ENDPOINT"),
+  credentials: { accessKeyId: get("R2_ACCESS_KEY_ID"), secretAccessKey: get("R2_SECRET_ACCESS_KEY") },
+});
+
+const MUSIC_RE = `^https?://maimaidx(-eng)?\\.(jp|com)/maimai-mobile/img/Music/`;
+
+async function listCoverKeys() {
+  const keys = new Set();
+  let token;
+  do {
+    const res = await r2.send(new ListObjectsV2Command({ Bucket: BUCKET, Prefix: "covers/", ContinuationToken: token }));
+    for (const o of res.Contents ?? []) if (o.Key) keys.add(o.Key.replace(/^covers\//, ""));
+    token = res.IsTruncated ? res.NextContinuationToken : undefined;
+  } while (token);
+  return keys;
+}
+
+async function pool(items, conc, fn) {
+  let i = 0;
+  await Promise.all(Array.from({ length: conc }, async () => {
+    while (i < items.length) { const idx = i++; await fn(items[idx], idx); }
+  }));
+}
+
+try {
+  console.log(APPLY ? "MODE: APPLY (will write)\n" : "MODE: DRY RUN (no writes)\n");
+
+  // md5 -> a source URL to download from (prefer the .jp URL actually in the DB)
+  const rows = await sql`
+    SELECT DISTINCT
+      regexp_replace(cover, '^.*/Music/([^/]+)\\.png$', '\\1') AS md5,
+      cover AS url
+    FROM songs
+    WHERE cover ~ ${MUSIC_RE}
+  `;
+  const md5ToUrl = new Map();
+  for (const r of rows) if (!md5ToUrl.has(r.md5)) md5ToUrl.set(r.md5, r.url);
+  console.log("distinct cover filenames:", md5ToUrl.size);
+
+  const r2Keys = await listCoverKeys();
+  const missing = [...md5ToUrl.keys()].filter(md5 => !r2Keys.has(`${md5}.webp`));
+  console.log("already in R2:", md5ToUrl.size - missing.length, " missing:", missing.length);
+
+  // Upload missing webps
+  const present = new Set([...md5ToUrl.keys()].filter(md5 => r2Keys.has(`${md5}.webp`)));
+  let uploaded = 0;
+  const failed = [];
+  if (missing.length) {
+    console.log(`\n${APPLY ? "Uploading" : "[dry] would upload"} ${missing.length} missing covers...`);
+    await pool(missing, 6, async (md5) => {
+      const url = md5ToUrl.get(md5);
+      try {
+        const res = await fetch(url, { dispatcher: agent, headers: { "User-Agent": "Mozilla/5.0" } });
+        if (!res.ok) throw new Error(`fetch ${res.status}`);
+        const buf = Buffer.from(await res.arrayBuffer());
+        const webp = await sharp(buf).webp({ quality: 80 }).toBuffer();
+        if (APPLY) {
+          await r2.send(new PutObjectCommand({
+            Bucket: BUCKET, Key: `covers/${md5}.webp`, Body: webp,
+            ContentType: "image/webp", CacheControl: "public, max-age=31536000",
+          }));
+        }
+        present.add(md5);
+        uploaded++;
+      } catch (e) {
+        failed.push(`${md5}: ${e.message}`);
+      }
+    });
+    console.log(`${APPLY ? "uploaded" : "would upload"}: ${uploaded}, failed: ${failed.length}`);
+    if (failed.length) console.log("failures:\n  " + failed.join("\n  "));
+  }
+
+  // Rewrite DB rows for confirmed-present filenames
+  const presentArr = [...present];
+  const toRewrite = await sql`
+    SELECT count(*)::int AS n FROM songs
+    WHERE cover ~ ${MUSIC_RE}
+      AND regexp_replace(cover, '^.*/Music/([^/]+)\\.png$', '\\1') = ANY(${sql.array(presentArr)})
+  `;
+  console.log(`\nrows to rewrite (covers present in R2): ${toRewrite[0].n}`);
+
+  if (APPLY) {
+    const res = await sql`
+      UPDATE songs
+      SET cover = ${R2_BASE} || '/covers/' || regexp_replace(cover, '^.*/Music/([^/]+)\\.png$', '\\1') || '.webp'
+      WHERE cover ~ ${MUSIC_RE}
+        AND regexp_replace(cover, '^.*/Music/([^/]+)\\.png$', '\\1') = ANY(${sql.array(presentArr)})
+    `;
+    console.log(`rewrote ${res.count} rows`);
+
+    const remaining = await sql`SELECT count(*)::int AS n FROM songs WHERE cover ~ ${MUSIC_RE}`;
+    console.log(`remaining maimaidx Music covers in DB: ${remaining[0].n}`);
+  } else {
+    console.log("[dry] re-run with --apply to upload + rewrite");
+  }
+} finally {
+  await sql.end();
+}

--- a/apps/main/src/app/api/admin/image/route.ts
+++ b/apps/main/src/app/api/admin/image/route.ts
@@ -6,7 +6,7 @@ import { listCoverKeys, uploadCoverToR2 } from "@/lib/r2";
 import { UpdateSong } from "@/lib/types/update";
 import { NextRequest, NextResponse } from "next/server";
 
-const MAIMAI_COVER_PATTERN = /^https?:\/\/maimaidx(?:-eng)?\.com\/maimai-mobile\/img\/Music\/(.+)$/;
+const MAIMAI_COVER_PATTERN = /^https?:\/\/(?:maimaidx\.jp|maimaidx(?:-eng)?\.com)\/maimai-mobile\/img\/Music\/(.+)$/;
 // Lxns CN jacket: https://assets2.lxns.net/maimai/jacket/{id}.png — namespace under
 // `lxns_{id}` to avoid collisions with the JP/INTL md5-style filenames.
 const LXNS_COVER_PATTERN = /^https?:\/\/assets2?\.lxns\.net\/maimai\/jacket\/(\d+)\.png$/;


### PR DESCRIPTION
## Problem

A large share of Vercel image-optimization **transformations** were being billed for song covers, e.g.:

```
/api/image-proxy?url=https%3A%2F%2Fmaimaidx.jp%2Fmaimai-mobile%2Fimg%2FMusic%2F...png
```

This was supposed to be handled by the `admin/image` route, which caches covers to R2 (pre-optimized webp) and rewrites `songs.cover` to the R2 URL so they render `unoptimized`. It wasn't working for most covers.

## Root cause

`MAIMAI_COVER_PATTERN` only matched `maimaidx.com` / `maimaidx-eng.com`, never **`maimaidx.jp`**, which is what the updater actually stores. So `extractFilename()` returned `null` for ~95% of covers, the route counted them as `unchanged`, and they stayed on maimaidx, served through `/api/image-proxy` and re-optimized by Next.js, billing a transformation per size/format.

Prod `songs` snapshot before the fix:

| Host | Rows |
|---|---|
| `maimaidx.jp` | 29,070 |
| `cdn.tomomai.lol` (R2) | 16,586 |
| `maimaidx-eng.com` | 35 |
| sega.jp / gamerch | 16 |

## Changes

- **Widen `MAIMAI_COVER_PATTERN`** to also match `maimaidx.jp`, so future updater runs migrate covers to R2 instead of regressing.
- **Add `scripts/migrate-covers-to-r2.mjs`** — one-shot backfill (dry-run by default, `--apply` to write): uploads any missing webps to R2, then rewrites `songs.cover` to the pre-optimized R2 URL. Guarded so only covers confirmed present in R2 get rewritten.

## Operational (already run against prod)

- Uploaded 100 missing webps to R2 (1,361 of 1,465 distinct covers already existed).
- Rewrote **29,071** rows to their R2 webp URL.
- 4 distinct covers (34 rows) are dead 404s on maimaidx; pointed those at their R2 URL form too so they no longer hit the optimizer (R2 404s instead of being proxied + transformed).

Result: `songs.cover` went from ~36% to **100%** off the optimization path.

## Notes

- `user_snapshots.iconUrl` was audited separately and is already 100% on R2.
- `courseRankUrl` / `classRankUrl` still point at official hosts but are only consumed by server-side canvas rendering (`render-image.ts`, Discord image util), not `next/image`, so they don't trigger transformations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure**
  * Optimized music cover storage and delivery with WebP image conversion and extended caching periods

* **Bug Fixes**
  * Enhanced cover image URL recognition to support additional maimaidx domain sources

<!-- end of auto-generated comment: release notes by coderabbit.ai -->