### PR TITLE
feat(main/fetch): stream fetch status over SSE instead of client polling

### DIFF
--- a/apps/main/src/app/api/trpc/[trpc]/route.ts
+++ b/apps/main/src/app/api/trpc/[trpc]/route.ts
@@ -3,6 +3,10 @@ import { appRouter } from '@/server/routers/_app';
 import { createTRPCContext } from '@/lib/trpc';
 import { NextRequest } from 'next/server';
 
+// onFetchStatus subscriptions hold the SSE connection open while a fetch runs
+// (the worker times out at 2 minutes); allow the function to outlive that.
+export const maxDuration = 130;
+
 const handler = (req: NextRequest) =>
   fetchRequestHandler({
     endpoint: '/api/trpc',

--- a/apps/main/src/app/api/v1/fetch/status/stream/route.ts
+++ b/apps/main/src/app/api/v1/fetch/status/stream/route.ts
@@ -1,0 +1,63 @@
+import { type NextRequest } from "next/server";
+import { withApiKey } from "@/lib/api/protect";
+import { parseQuery } from "@/lib/api/parse-query";
+import { watchFetchStatusServer } from "@/lib/maimai-server-actions";
+import { Region } from "@/lib/types";
+import { spec } from "./spec";
+
+// SSE streams hold the connection open while the fetch runs (worker times out
+// at 2 minutes), so allow the function to live a little longer than that.
+export const dynamic = "force-dynamic";
+export const maxDuration = 130;
+
+export const GET = withApiKey(["fetch:read"], async (req: NextRequest, key) => {
+  const parsed = parseQuery(req.nextUrl.searchParams, spec.query!);
+  if (parsed instanceof Response) return parsed;
+  const { region, sessionId } = parsed;
+
+  const encoder = new TextEncoder();
+
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const send = (event: string, data: unknown) => {
+        controller.enqueue(
+          encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`),
+        );
+      };
+
+      try {
+        for await (const status of watchFetchStatusServer(key.userId, region as Region, {
+          sessionId,
+          signal: req.signal,
+        })) {
+          send("status", {
+            id: status.id,
+            status: status.status,
+            startedAt: status.startedAt.toISOString(),
+            completedAt: status.completedAt ? status.completedAt.toISOString() : null,
+            errorMessage: status.errorMessage,
+            statusStates: status.statusStates,
+            notFoundScores: status.notFoundScores,
+          });
+        }
+        send("done", { ok: true });
+      } catch (err) {
+        send("error", {
+          error: err instanceof Error ? err.message : "stream error",
+        });
+      } finally {
+        controller.close();
+      }
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream; charset=utf-8",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+      // Disable proxy buffering so events flush immediately.
+      "X-Accel-Buffering": "no",
+    },
+  });
+});

--- a/apps/main/src/app/api/v1/fetch/status/stream/spec.ts
+++ b/apps/main/src/app/api/v1/fetch/status/stream/spec.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+import { defineRoute } from "@/lib/api/registry";
+import { fetchStatus, regionSchema } from "@/lib/api/schemas";
+
+export const spec = defineRoute({
+  method: "GET",
+  path: "/api/v1/fetch/status/stream",
+  tag: "Fetch",
+  summary: "Stream fetch status updates (Server-Sent Events)",
+  description:
+    "Server-Sent Events stream of the latest fetch session for the caller in " +
+    "the given region. Emits a `status` event (data shaped like " +
+    "`GET /api/v1/fetch/status`) whenever progress changes, then a final " +
+    "`status` plus a `done` event once the fetch reaches `completed` or " +
+    "`failed`, after which the stream closes. Use this instead of polling " +
+    "`GET /api/v1/fetch/status`. Pass `sessionId` to restrict the stream to a " +
+    "specific session; omit it to follow the latest session for the region.",
+  scope: "fetch:read",
+  cost: 5,
+  query: z.object({
+    region: regionSchema,
+    sessionId: z
+      .string()
+      .optional()
+      .describe("Restrict the stream to a specific fetch session id."),
+  }),
+  response: fetchStatus,
+});

--- a/apps/main/src/hooks/useFetchSession.ts
+++ b/apps/main/src/hooks/useFetchSession.ts
@@ -1,5 +1,6 @@
-import { useState, useEffect, useRef, useCallback, useMemo } from "react";
-import { trpc, trpcClient } from "@/lib/trpc-client";
+import { useState, useRef, useCallback, useMemo } from "react";
+import { skipToken } from "@tanstack/react-query";
+import { trpc } from "@/lib/trpc-client";
 import { toast } from "sonner";
 import { Region, FetchSession } from "@/lib/types";
 import { Flags } from "@/lib/flags";
@@ -7,75 +8,82 @@ import { isTokenError, isAlbumSettingsError, isCnCookiesSingleUseError } from "@
 import { parseStatusStates } from "@/lib/fetch-states";
 import { FetchToastState } from "@/components/fetch-toast";
 
+// What the SSE subscription should watch. `sessionId` present → watch that
+// specific session; absent → detect-and-watch the next new session (the
+// external token-submit flow). null → idle, no subscription.
+interface WatchTarget {
+  region: Region;
+  sessionId?: string;
+}
+
 export function useFetchSession(onFetchComplete?: () => void, flags?: Flags, onTokenError?: () => void, onUseAlbumError?: () => void, onCnCookiesExpired?: () => void) {
   const [currentSession, setCurrentSession] = useState<FetchSession | null>(null);
   const [fetchError, setFetchError] = useState<string | null>(null);
   const [lastFetchTime, setLastFetchTime] = useState<Date | null>(null);
 
-  // Session polling state
-  const [sessionPollingEnabled, setSessionPollingEnabled] = useState(false);
-  const [sessionPollingRegion, setSessionPollingRegion] = useState<Region | null>(null);
-  const lastKnownSessionIdRef = useRef<string | null>(null);
-  const onSessionDetectedRef = useRef<(() => void) | undefined>(undefined);
+  // Drives a single SSE subscription (trpc.user.onFetchStatus). null = idle.
+  const [watchTarget, setWatchTarget] = useState<WatchTarget | null>(null);
+  // True only while waiting for an externally-submitted token to create a
+  // session (detect mode, before the session is observed).
+  const [isDetecting, setIsDetecting] = useState(false);
 
-  // Poll for new fetch sessions (lightweight query)
-  const { data: latestSessionData } = trpc.user.getLatestFetchSessionId.useQuery(
-    { region: sessionPollingRegion! },
+  const onSessionDetectedRef = useRef<(() => void) | undefined>(undefined);
+  // Guards the one-time "session detected" side effects. False only while in
+  // detect mode (startSessionPolling) before the new session is observed;
+  // true in session mode (startFetch) where the session is already known.
+  const detectedRef = useRef(false);
+
+  // Single push-based subscription. Replaces the old getLatestFetchSessionId
+  // (1s) and getFetchStatus (0.5s) polling loops.
+  trpc.user.onFetchStatus.useSubscription(
+    watchTarget
+      ? { region: watchTarget.region, sessionId: watchTarget.sessionId }
+      : skipToken,
     {
-      enabled: sessionPollingEnabled && sessionPollingRegion !== null,
-      refetchInterval: 1000, // Poll every 1 seconds
-      refetchOnWindowFocus: false,
+      onData: (status) => {
+        // First emission in detect mode means a new session was created.
+        if (!detectedRef.current) {
+          detectedRef.current = true;
+          setIsDetecting(false);
+          setLastFetchTime(new Date());
+          toast.success("Token submitted successfully");
+          onSessionDetectedRef.current?.();
+        }
+
+        const updatedSession: FetchSession = {
+          id: status.id,
+          status: status.status,
+          startedAt: status.startedAt,
+          completedAt: status.completedAt ?? undefined,
+          errorMessage: status.errorMessage ?? undefined,
+          statusStates: status.statusStates ?? undefined,
+        };
+        setCurrentSession(updatedSession);
+
+        if (status.status === "completed") {
+          if (status.notFoundScores && status.notFoundScores.length > 0) {
+            toast.warning(`${status.notFoundScores.length} songs not found in database`, {
+              description: status.notFoundScores.map((score) => `${score.songName} (${score.difficulty})`).join(", "),
+            });
+          }
+          onFetchComplete?.();
+          setWatchTarget(null); // terminal — close the subscription
+        } else if (status.status === "failed") {
+          const errorMessage = status.errorMessage || "Fetch failed";
+          setFetchError(errorMessage);
+          if (isTokenError(errorMessage)) onTokenError?.();
+          if (isAlbumSettingsError(errorMessage)) onUseAlbumError?.();
+          setWatchTarget(null); // terminal — close the subscription
+        }
+      },
+      onError: (error) => {
+        // Transient connection drops shouldn't be surfaced as fetch failures —
+        // the DB session status remains the source of truth and the link will
+        // reconnect. Log for visibility only.
+        console.error("Fetch status subscription error:", error);
+      },
     }
   );
-
-  // Detect new sessions
-  useEffect(() => {
-    if (!latestSessionData || !sessionPollingEnabled) return;
-
-    const currentSessionId = latestSessionData.id;
-
-    console.log("[Session Polling] Current session ID:", currentSessionId, "Last known:", lastKnownSessionIdRef.current);
-
-    // Initialize the last known session ID on first poll
-    if (lastKnownSessionIdRef.current === null) {
-      console.log("[Session Polling] Initializing with session ID:", currentSessionId);
-      lastKnownSessionIdRef.current = currentSessionId;
-      return;
-    }
-
-    // Check if a new session was created
-    if (currentSessionId !== lastKnownSessionIdRef.current) {
-      console.log("[Session Polling] NEW SESSION DETECTED! Old:", lastKnownSessionIdRef.current, "New:", currentSessionId);
-      lastKnownSessionIdRef.current = currentSessionId;
-
-      // Show success toast
-      toast.success("Token submitted successfully");
-      console.log("Token submitted successfully, on " + sessionPollingRegion + " region");
-
-      // Stop session polling
-      setSessionPollingEnabled(false);
-
-      // Start full fetch status polling for the new session
-      if (sessionPollingRegion) {
-        const session: FetchSession = {
-          id: currentSessionId,
-          status: "pending",
-          startedAt: new Date(latestSessionData.startedAt),
-        };
-        setCurrentSession(session);
-        setLastFetchTime(new Date());
-        setFetchError(null);
-
-        // Start polling for the new session
-        pollFetchStatus(currentSessionId, sessionPollingRegion);
-      }
-
-      // Call the callback if provided
-      if (onSessionDetectedRef.current) {
-        onSessionDetectedRef.current();
-      }
-    }
-  }, [latestSessionData, sessionPollingEnabled, sessionPollingRegion]);
 
   // tRPC mutation for starting fetch
   const startFetchMutation = trpc.user.startFetch.useMutation({
@@ -89,8 +97,10 @@ export function useFetchSession(onFetchComplete?: () => void, flags?: Flags, onT
       setLastFetchTime(new Date());
       setFetchError(null);
 
-      // Start polling immediately with the returned session ID
-      pollFetchStatus(data.sessionId, variables.region);
+      // Watch this specific session via the subscription.
+      detectedRef.current = true; // session is already known; skip detect logic
+      setIsDetecting(false);
+      setWatchTarget({ region: variables.region, sessionId: data.sessionId });
     },
     onError: (error) => {
       if (isAlbumSettingsError(error.message) && !!onUseAlbumError) {
@@ -123,99 +133,28 @@ export function useFetchSession(onFetchComplete?: () => void, flags?: Flags, onT
     return startDataFetch(region); // No token provided, will use saved token
   };
 
-  const pollFetchStatus = async (sessionId: string, region: Region) => {
-    const maxAttempts = 600; // 5 minutes max (300 seconds / 0.5 second = 600 attempts)
-    let attempts = 0;
-
-    const poll = async () => {
-      try {
-        // Query the latest fetch status directly using tRPC client
-        const result = await trpcClient.user.getFetchStatus.query({
-          region,
-        });
-
-        if (result && result.id === sessionId) {
-          // Only update if this is the session we're tracking
-          const updatedSession: FetchSession = {
-            id: result.id,
-            status: result.status,
-            startedAt: result.startedAt,
-            completedAt: result.completedAt || undefined,
-            errorMessage: result.errorMessage || undefined,
-            statusStates: result.statusStates || undefined,
-          };
-          console.log("Fetch status updated for session " + sessionId + " on " + region + " region: " + JSON.stringify(updatedSession));
-          setCurrentSession(updatedSession);
-
-          if (result.status === "completed") {
-            // Show warning toast for not found scores (separate from the custom toast)
-            if (result.notFoundScores && result.notFoundScores.length > 0) {
-              toast.warning(`${result.notFoundScores.length} songs not found in database`, {
-                description: result.notFoundScores.map(score => `${score.songName} (${score.difficulty})`).join(", "),
-              });
-            }
-            onFetchComplete?.();
-            return "completed";
-          } else if (result.status === "failed") {
-            const errorMessage = result.errorMessage || "Fetch failed";
-            setFetchError(errorMessage);
-
-            // Check if this is a token-related error and trigger callback
-            if (isTokenError(errorMessage)) {
-              onTokenError?.();
-            }
-
-            // Check if this is an album settings error
-            if (isAlbumSettingsError(errorMessage)) {
-              onUseAlbumError?.();
-            }
-
-            return "failed";
-          }
-        } else if (!result) {
-          // No fetch sessions found at all
-          setFetchError("Fetch session not found");
-          return "error";
-        }
-
-        attempts++;
-        if (attempts < maxAttempts) {
-          setTimeout(poll, 500); // Poll every 0.5 second
-        } else {
-          setFetchError("Fetch timeout");
-          return "timeout";
-        }
-      } catch (error) {
-        console.error("Error polling fetch status:", error);
-        setFetchError("Failed to check fetch status");
-        return "error";
-      }
-    };
-
-    return poll();
-  };
-
   const resetFetchSession = useCallback(() => {
     setCurrentSession(null);
     setFetchError(null);
   }, []);
 
-  // Start polling for new sessions
+  // Start watching for a session created by the external token-submit flow.
   const startSessionPolling = useCallback((region: Region, onSessionDetected?: () => void) => {
-    console.log("[startSessionPolling] Starting session polling for region:", region);
-    setSessionPollingRegion(region);
-    setSessionPollingEnabled(true);
-    lastKnownSessionIdRef.current = null; // Reset to detect the first session
+    detectedRef.current = false;
     onSessionDetectedRef.current = onSessionDetected;
+    setFetchError(null);
+    setIsDetecting(true);
+    setWatchTarget({ region }); // detect mode — no sessionId
   }, []);
 
-  // Stop polling for new sessions
+  // Stop watching for a new session.
   const stopSessionPolling = useCallback(() => {
-    console.log("[stopSessionPolling] Stopping session polling");
-    setSessionPollingEnabled(false);
-    setSessionPollingRegion(null);
-    lastKnownSessionIdRef.current = null;
+    setIsDetecting(false);
+    detectedRef.current = false;
     onSessionDetectedRef.current = undefined;
+    // Only tear down the subscription if we were still in detect mode; once a
+    // session is being watched we let it run to completion.
+    setWatchTarget((prev) => (prev && !prev.sessionId ? null : prev));
   }, []);
 
   const isFetching = currentSession?.status === "pending" || startFetchMutation.isPending;
@@ -243,7 +182,7 @@ export function useFetchSession(onFetchComplete?: () => void, flags?: Flags, onT
     resetFetchSession,
     startSessionPolling,
     stopSessionPolling,
-    isPollingForSession: sessionPollingEnabled,
+    isPollingForSession: isDetecting,
     fetchToastState,
   };
 }

--- a/apps/main/src/lib/api/specs.ts
+++ b/apps/main/src/lib/api/specs.ts
@@ -21,6 +21,7 @@ import "@/app/api/v1/plates/spec";
 import "@/app/api/v1/me/settings/spec";
 import "@/app/api/v1/fetch/spec";
 import "@/app/api/v1/fetch/status/spec";
+import "@/app/api/v1/fetch/status/stream/spec";
 import "@/app/api/v1/fetch/token/spec";
 
 export { getRegistry, findRouteBySlug, routeSlug } from "./registry";

--- a/apps/main/src/lib/maimai-server-actions.ts
+++ b/apps/main/src/lib/maimai-server-actions.ts
@@ -350,3 +350,91 @@ export async function getFetchStatusServer(userId: string, region: Region): Prom
     notFoundScores: typeof session.extraData === "object" && session.extraData !== null && "notFoundScores" in session.extraData ? (session.extraData as { notFoundScores?: { songName: string; difficulty: string; musicType: string }[] }).notFoundScores ?? null : null,
   };
 }
+
+// Resolves after `ms`, or immediately when the abort signal fires — lets the
+// watch loop wake up promptly on client disconnect instead of waiting out the
+// full interval.
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal?.aborted) return resolve();
+    const timer = setTimeout(resolve, ms);
+    signal?.addEventListener(
+      'abort',
+      () => {
+        clearTimeout(timer);
+        resolve();
+      },
+      { once: true },
+    );
+  });
+}
+
+export interface WatchFetchStatusOptions {
+  /** Only emit for this specific session (publicId); other sessions are ignored. */
+  sessionId?: string;
+  /** Server-side DB poll cadence in ms. Defaults to 750ms (≈ the old client poll). */
+  intervalMs?: number;
+  /** Hard cap on total watch duration in ms. Must stay under the serverless timeout. */
+  maxDurationMs?: number;
+  /** Abort signal — ends the stream when the client disconnects. */
+  signal?: AbortSignal;
+}
+
+/**
+ * Async generator that watches a region's latest fetch session and yields the
+ * status whenever it changes, closing once the fetch reaches a terminal state
+ * (or the duration cap / abort signal fires).
+ *
+ * In serverless there is no cross-invocation pub/sub, so this polls the DB
+ * server-side. It backs both the `onFetchStatus` tRPC subscription and the
+ * REST SSE endpoint, so the client no longer has to poll.
+ *
+ * Two modes:
+ *  - `sessionId` provided → watch that session until terminal.
+ *  - `sessionId` omitted (detect mode) → record the latest session at start as
+ *    a baseline, then adopt and watch the first newer session that appears.
+ *    Used by the external token-submit flow that waits for a session to show up.
+ */
+export async function* watchFetchStatusServer(
+  userId: string,
+  region: Region,
+  options: WatchFetchStatusOptions = {},
+): AsyncGenerator<FetchStatusResult> {
+  const intervalMs = options.intervalMs ?? 750;
+  const maxDurationMs = options.maxDurationMs ?? 130_000;
+  const { signal, sessionId } = options;
+  const startedAt = Date.now();
+
+  let target = sessionId;
+  let baselineId: string | null | undefined;
+  let lastSignature: string | null = null;
+
+  while (!signal?.aborted && Date.now() - startedAt < maxDurationMs) {
+    const status = await getFetchStatusServer(userId, region);
+
+    if (status) {
+      if (!target) {
+        // Detect mode: capture baseline on first read, then adopt the next
+        // session whose id differs from it.
+        if (baselineId === undefined) {
+          baselineId = status.id;
+        } else if (status.id !== baselineId) {
+          target = status.id;
+        }
+      }
+
+      if (target && status.id === target) {
+        const signature = `${status.status}|${status.statusStates ?? ''}|${status.errorMessage ?? ''}`;
+        if (signature !== lastSignature) {
+          lastSignature = signature;
+          yield status;
+        }
+        if (status.status === 'completed' || status.status === 'failed') {
+          return;
+        }
+      }
+    }
+
+    await sleep(intervalMs, signal);
+  }
+}

--- a/apps/main/src/lib/trpc-client.ts
+++ b/apps/main/src/lib/trpc-client.ts
@@ -1,5 +1,5 @@
 import { createTRPCReact } from '@trpc/react-query';
-import { httpBatchLink } from '@trpc/client';
+import { httpBatchLink, httpSubscriptionLink, splitLink } from '@trpc/client';
 import type { AppRouter } from '@/server/routers/_app';
 import superjson from 'superjson';
 
@@ -7,13 +7,22 @@ export const trpc = createTRPCReact<AppRouter>();
 
 export const trpcClient = trpc.createClient({
   links: [
-    httpBatchLink({
-      url: '/api/trpc',
-      transformer: superjson,
-      // You can pass HTTP headers you wish here (typed as Record<string, string>)
-      async headers(): Promise<Record<string, string>> {
-        return {};
-      },
+    // Route subscriptions over SSE (httpSubscriptionLink) and everything else
+    // over the batched HTTP link.
+    splitLink({
+      condition: (op) => op.type === 'subscription',
+      true: httpSubscriptionLink({
+        url: '/api/trpc',
+        transformer: superjson,
+      }),
+      false: httpBatchLink({
+        url: '/api/trpc',
+        transformer: superjson,
+        // You can pass HTTP headers you wish here (typed as Record<string, string>)
+        async headers(): Promise<Record<string, string>> {
+          return {};
+        },
+      }),
     }),
   ],
 });

--- a/apps/main/src/server/routers/user/fetch.ts
+++ b/apps/main/src/server/routers/user/fetch.ts
@@ -1,7 +1,7 @@
 import { db } from '@/lib/db';
 import { generateUserOtp, getOtpExpiryTimestamp, createOpaqueUserId } from '@/lib/otp';
 import { resolveBaseUrl } from '@/lib/base-url';
-import { getFetchStatusServer, startFetchServer } from '@/lib/maimai-server-actions';
+import { getFetchStatusServer, startFetchServer, watchFetchStatusServer } from '@/lib/maimai-server-actions';
 import { getLogger } from '@/lib/request-logger';
 import { protectedProcedure, router } from '@/lib/trpc';
 import { Region } from '@/lib/types';
@@ -79,6 +79,23 @@ export const fetchRouter = router({
     }))
     .query(async ({ ctx, input }) => {
       return await getFetchStatusServer(ctx.session.user.id, input.region as Region);
+    }),
+
+  // SSE subscription: pushes fetch status to the client instead of having it
+  // poll getFetchStatus/getLatestFetchSessionId. Yields whenever progress
+  // changes and closes once the fetch reaches a terminal state.
+  //  - sessionId set   → watch that session.
+  //  - sessionId unset → detect-and-watch the next new session (token-submit flow).
+  onFetchStatus: protectedProcedure
+    .input(z.object({
+      region: regionSchema,
+      sessionId: z.string().optional(),
+    }))
+    .subscription(async function* ({ ctx, input, signal }) {
+      yield* watchFetchStatusServer(ctx.session.user.id, input.region as Region, {
+        sessionId: input.sessionId,
+        signal,
+      });
     }),
 
   getLatestFetchSessionId: protectedProcedure

--- a/apps/main/src/server/routers/user/index.ts
+++ b/apps/main/src/server/routers/user/index.ts
@@ -39,6 +39,7 @@ export const userRouter = router({
   getLoginOtp: fetchRouter.getLoginOtp,
   startFetch: fetchRouter.startFetch,
   getFetchStatus: fetchRouter.getFetchStatus,
+  onFetchStatus: fetchRouter.onFetchStatus,
   getLatestFetchSessionId: fetchRouter.getLatestFetchSessionId,
   deleteToken: fetchRouter.deleteToken,
 


### PR DESCRIPTION
Replace the client-side fetch status polling (getLatestFetchSessionId
every 1s + getFetchStatus every 0.5s) with a push-based SSE channel so
the browser no longer polls.

- Add watchFetchStatusServer async generator in maimai-server-actions
  that yields a region's latest fetch session on change and closes on a
  terminal state. In serverless there is no cross-invocation pub/sub, so
  it polls the DB server-side (single connection, tunable cadence) and is
  reused by both surfaces below. Supports a watch mode (specific
  sessionId) and a detect mode (adopt the next new session) so it covers
  the external token-submit flow too.
- Add user.onFetchStatus tRPC subscription (async generator procedure)
  and wire the client transport with splitLink + httpSubscriptionLink.
- Rewrite useFetchSession to drive a single useSubscription off a watch
  target, dropping both setTimeout/refetchInterval polling loops while
  keeping the same toast/callback behavior.
- Add GET /api/v1/fetch/status/stream SSE endpoint for REST consumers so
  they no longer poll /api/v1/fetch/status (left intact as a fallback).

The start endpoints keep returning fast JSON; only the watch is streamed.
Set maxDuration=130 on the tRPC and SSE routes so a stream can outlive
the worker's 2-minute timeout.