### PR TITLE
fix(main/discord): register commands for all contexts

### DIFF
--- a/apps/main/scripts/register-discord-commands.js
+++ b/apps/main/scripts/register-discord-commands.js
@@ -96,6 +96,7 @@ async function registerCommands() {
         body: JSON.stringify(commands.map(command => ({
           ...command,
           integration_types: [0, 1],
+          contexts: [0, 1, 2],
         }))),
       }
     );
@@ -117,4 +118,4 @@ async function registerCommands() {
   }
 }
 
-registerCommands(); 
+registerCommands();


### PR DESCRIPTION
Discord's default interaction contexts when registering commands possibly doesn't include `PRIVATE_CHANNEL` when the integration types contains both `GUILD_INSTALL` and `USER_INSTALL`.

Adds a `contexts` param to the request so commands can be used in all supported contexts like guilds, bot specific DMs and other user DMs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Discord bot command registration configuration to specify available command contexts, ensuring proper command availability across different interaction types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->