### PR TITLE
fix(main/profile): wrap DataContent in Suspense to fix static-render …

### DIFF
--- a/apps/main/src/components/profile-page.tsx
+++ b/apps/main/src/components/profile-page.tsx
@@ -5,6 +5,7 @@ import { Flags } from "@/lib/flags";
 import { Difficulty, EventData, ProfileData, Region, SnapshotWithSongs, SongWithScore, TitleType } from "@/lib/types";
 import { TomomaiAI } from "@/components/tomomai-ai";
 import { VersionId } from "@/lib/metadata";
+import { Suspense } from "react";
 
 interface SnapshotData {
   snapshot: {
@@ -98,16 +99,18 @@ export function ProfilePage({
           profileUsername={username}
         />
 
-        <DataContent
-          region={region}
-          selectedSnapshotData={snapshotWithSongs}
-          isLoading={false}
-          privacySettings={snapshotData.privacySettings}
-          visitableProfileAt={username}
-          initialTab={initialTab}
-          visitedBySelf={false}
-          flags={flags}
-        />
+        <Suspense>
+          <DataContent
+            region={region}
+            selectedSnapshotData={snapshotWithSongs}
+            isLoading={false}
+            privacySettings={snapshotData.privacySettings}
+            visitableProfileAt={username}
+            initialTab={initialTab}
+            visitedBySelf={false}
+            flags={flags}
+          />
+        </Suspense>
       </div>
       <TomomaiAI snapshotData={snapshotWithSongs} region={region} aprilFools2026={flags.aprilFools2026} />
     </div>


### PR DESCRIPTION
…bailout

Making /profile/[username]/[region] static (ISR) turned DataContent's useSearchParams() call into a static-render bailout. With no Suspense boundary above it the bailout became a 500 ("useSearchParams() should be wrapped in a suspense boundary").

Wrap <DataContent> in <Suspense>. The interactive tabbed data hydrates on the client; the SEO-critical shell (identity, metadata, JSON-LD, snapshot existence) still server-renders, and the route stays ● ISR.

The same component on the dashboard (/) is unaffected — that page is force-dynamic, so useSearchParams resolves at request time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the profile page’s loading behavior by displaying content through a loading boundary, making the page feel smoother while data is being fetched.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->