### PR TITLE
feat(main/discord): staleness-aware refetch prompt and fetch option

### DIFF
--- a/apps/main/messages/discord/en-GB.json
+++ b/apps/main/messages/discord/en-GB.json
@@ -1,0 +1,189 @@
+{
+  "common": {
+    "footer": "tomomai ともマイ • maimai DX score tracker",
+    "notRegistered": {
+      "title": "❌ Not Registered",
+      "description": "You haven't linked your Discord account to tomomai yet!",
+      "getStarted": {
+        "name": "🔗 Get Started",
+        "value": "[Visit tomomai ともマイ]({baseUrl}/) to sign in with Discord and start tracking your scores!"
+      }
+    },
+    "noData": {
+      "title": "📊 No Data Found",
+      "description": "You don't have any {regionName} region data yet!",
+      "import": {
+        "name": "🎯 Import Your Scores",
+        "value": "[Visit tomomai ともマイ]({baseUrl}/) to import your {regionName} maimai DX scores!"
+      }
+    },
+    "error": {
+      "title": "❌ Error",
+      "unableToIdentify": "Unable to identify Discord user. Please try again.",
+      "unableToIdentifyShort": "Unable to identify Discord user.",
+      "generic": "An error occurred. Please try again later.",
+      "notAvailableToYou": "❌ This button is not available to you.",
+      "unknownCommand": "Unknown command"
+    },
+    "loading": {
+      "title": "⏳ Loading...",
+      "description": "<@{userId}> Continuing with your current data..."
+    }
+  },
+  "staleness": {
+    "title": "⏳ Stale Data",
+    "description": "<@{userId}> Your last **{regionName}** fetch was **{age}** ago.\n{cmdLine}",
+    "cmdLine": {
+      "profile": "Do you still want to view your profile?",
+      "recents": "Do you still want to view your recent plays?",
+      "recommend": "Do you still want to view your recommendations?",
+      "daily": "Do you still want to generate your daily plays for {day}?",
+      "dailyDefault": "Do you still want to generate your daily plays?",
+      "default": "Do you want to continue?"
+    },
+    "buttons": {
+      "continue": "Continue",
+      "refetchAndContinue": "Refetch and continue"
+    },
+    "refetching": {
+      "title": "🔄 Refetching {regionName} Data",
+      "description": "<@{userId}> Refetching from maimai DX NET, then continuing..."
+    },
+    "refetchError": {
+      "title": "❌ Error",
+      "description": "<@{userId}> An error occurred while refetching. Please try again later."
+    }
+  },
+  "fetch": {
+    "maintenanceWindow": "Cannot fetch data during maintenance window (4AM - 7AM JST)",
+    "startError": "An error occurred while starting the fetch. Please try again later.",
+    "initializing": {
+      "title": "🔄 Fetching {regionName} Data",
+      "description": "<@{userId}> Starting data fetch from maimai DX NET...",
+      "status": "📊 Status",
+      "statusValue": "Initialising..."
+    },
+    "error": {
+      "title": "❌ Fetch Error",
+      "description": "<@{userId}> An error occurred while fetching your data: {message}"
+    },
+    "failed": {
+      "title": "❌ Fetch Failed",
+      "description": "<@{userId}> Failed to fetch {regionName} data: {reason}"
+    },
+    "timeout": {
+      "title": "⏰ Fetch Timeout",
+      "description": "<@{userId}> The fetch is taking longer than expected. Please check your data on the website.",
+      "statusName": "🌐 Check Status",
+      "statusValue": "[Visit tomomai ともマイ]({baseUrl}/) to see your latest data!"
+    },
+    "complete": {
+      "title": "✅ Fetch Complete",
+      "description": "<@{userId}> Data fetch completed successfully!"
+    },
+    "generatingImage": {
+      "title": "🔄 Fetching {regionName} Data",
+      "description": "<@{userId}> Data fetch completed, generating profile image...",
+      "status": "📊 Status",
+      "statusValue": "⏳ Generating Profile Image"
+    },
+    "progress": {
+      "title": "🔄 Fetching {regionName} Data",
+      "description": "<@{userId}> Fetching data from maimai DX NET...",
+      "status": "📊 Status"
+    },
+    "albumPreference": {
+      "title": "⚙️ Album Privacy Settings Required",
+      "description": "<@{userId}> Before fetching data, you need to set your album privacy preference.",
+      "whatName": "What is this?",
+      "whatValue": "Albums are images stored with your profile data. You can choose whether to save them or not based on your privacy preferences.",
+      "privacyName": "Privacy Assurance",
+      "privacyValue": "✓ Albums are stored in your private profile\n✓ Not shared publicly unless you make them public\n✓ Only you can see them\n✓ Automatically deleted after 30 days\n✓ You can change this setting anytime",
+      "dontSave": "Don't Save Albums",
+      "save": "Save Albums",
+      "preferenceSet": {
+        "title": "✅ Preference Set",
+        "description": "Your album preference has been set to \"{choice}\". Starting fetch...",
+        "save": "Save Albums",
+        "dontSave": "Don't Save Albums"
+      }
+    }
+  },
+  "profile": {
+    "loading": {
+      "title": "🔄 Loading {regionName} Profile",
+      "description": "<@{userId}> Generating your profile image...",
+      "status": "📊 Status",
+      "statusValue": "⏳ Generating Profile Image"
+    },
+    "error": "An error occurred while fetching your rating. Please try again later.",
+    "content": "<@{userId}> {comment}, you only have **{rating}** rating! 😤{regionSuffix}\n-# New Charts: {newRating} (avg: {newAvg}) - Old Charts: {oldRating} (avg: {oldAvg}) - Stars: {stars} - Total Plays: {totalPlays}",
+    "viewFullProfile": "🔗 View Full Profile"
+  },
+  "recents": {
+    "loading": {
+      "title": "🔄 Loading {regionName} Recent Plays",
+      "description": "<@{userId}> Generating your recent play image...",
+      "status": "📊 Status",
+      "statusValue": "⏳ Generating Image"
+    },
+    "noPlays": {
+      "title": "📊 No Recent Plays Found",
+      "description": "You don't have any recent {regionName} region plays yet!",
+      "noMore": "No more plays found."
+    },
+    "error": {
+      "title": "❌ Error",
+      "description": "Failed to generate image: {message}"
+    },
+    "content": "<@{userId}> Here are your recent plays at <t:{unix}:f> ({regionName})",
+    "newerPlay": "Newer Play",
+    "olderPlay": "Older Play",
+    "errorGeneric": "An error occurred while fetching your recent plays. Please try again later."
+  },
+  "recommend": {
+    "title": "🎯 {regionName} Recommendations",
+    "description": "<@{userId}>\n```\n{body}\n```",
+    "none": {
+      "title": "🎯 {regionName} Recommendations",
+      "description": "<@{userId}> No recommendations — your scores are already optimal!"
+    },
+    "errorGeneric": "An error occurred while generating recommendations. Please try again later.",
+    "errorContent": "An error occurred while generating recommendations. Please try again later."
+  },
+  "daily": {
+    "noPlays": "<@{userId}> No plays found{day} ({regionName}).",
+    "content": "<@{userId}> Daily plays for **{day}** ({regionName})",
+    "failed": "<@{userId}> ❌ Failed to generate daily plays image.",
+    "errorGeneric": "An error occurred while fetching your daily plays. Please try again later.",
+    "play": "play",
+    "plays": "plays"
+  },
+  "invite": {
+    "title": "🎯 Invite tomomai ともマイ",
+    "description": "Add tomomai ともマイ bot to your Discord server to track and share maimai DX scores!",
+    "featuresName": "✨ Features",
+    "featuresValue": "• Track scores across International and Japan regions\n• Import data directly from maimai DX NET\n• View historical progress with snapshots\n• Beautiful score analysis and rating calculations",
+    "addName": "🔗 Add to Server",
+    "addValue": "[Click here to invite the bot]({url})",
+    "websiteName": "🌐 Website"
+  },
+  "regions": {
+    "intl": "International",
+    "jp": "Japan",
+    "cn": "China"
+  },
+  "age": {
+    "justNow": "just now",
+    "minute": "1 minute",
+    "minutes": "{count} minutes",
+    "hour": "1 hour",
+    "hours": "{count} hours",
+    "day": "1 day",
+    "days": "{count} days",
+    "month": "1 month",
+    "months": "{count} months",
+    "year": "1 year",
+    "years": "{count} years"
+  }
+}

--- a/apps/main/messages/discord/en-GB.json
+++ b/apps/main/messages/discord/en-GB.json
@@ -152,7 +152,8 @@
     "errorContent": "An error occurred while generating recommendations. Please try again later."
   },
   "daily": {
-    "noPlays": "<@{userId}> No plays found{day} ({regionName}).",
+    "noPlays": "<@{userId}> No plays found ({regionName}).",
+    "noPlaysDay": "<@{userId}> No plays found for {day} ({regionName}).",
     "content": "<@{userId}> Daily plays for **{day}** ({regionName})",
     "failed": "<@{userId}> ❌ Failed to generate daily plays image.",
     "errorGeneric": "An error occurred while fetching your daily plays. Please try again later.",

--- a/apps/main/messages/discord/en-US.json
+++ b/apps/main/messages/discord/en-US.json
@@ -1,0 +1,189 @@
+{
+  "common": {
+    "footer": "tomomai ともマイ • maimai DX score tracker",
+    "notRegistered": {
+      "title": "❌ Not Registered",
+      "description": "You haven't linked your Discord account to tomomai yet!",
+      "getStarted": {
+        "name": "🔗 Get Started",
+        "value": "[Visit tomomai ともマイ]({baseUrl}/) to sign in with Discord and start tracking your scores!"
+      }
+    },
+    "noData": {
+      "title": "📊 No Data Found",
+      "description": "You don't have any {regionName} region data yet!",
+      "import": {
+        "name": "🎯 Import Your Scores",
+        "value": "[Visit tomomai ともマイ]({baseUrl}/) to import your {regionName} maimai DX scores!"
+      }
+    },
+    "error": {
+      "title": "❌ Error",
+      "unableToIdentify": "Unable to identify Discord user. Please try again.",
+      "unableToIdentifyShort": "Unable to identify Discord user.",
+      "generic": "An error occurred. Please try again later.",
+      "notAvailableToYou": "❌ This button is not available to you.",
+      "unknownCommand": "Unknown command"
+    },
+    "loading": {
+      "title": "⏳ Loading...",
+      "description": "<@{userId}> Continuing with your current data..."
+    }
+  },
+  "staleness": {
+    "title": "⏳ Stale Data",
+    "description": "<@{userId}> Your last **{regionName}** fetch was **{age}** ago.\n{cmdLine}",
+    "cmdLine": {
+      "profile": "Do you still want to view your profile?",
+      "recents": "Do you still want to view your recent plays?",
+      "recommend": "Do you still want to view your recommendations?",
+      "daily": "Do you still want to generate your daily plays for {day}?",
+      "dailyDefault": "Do you still want to generate your daily plays?",
+      "default": "Do you want to continue?"
+    },
+    "buttons": {
+      "continue": "Continue",
+      "refetchAndContinue": "Refetch and continue"
+    },
+    "refetching": {
+      "title": "🔄 Refetching {regionName} Data",
+      "description": "<@{userId}> Refetching from maimai DX NET, then continuing..."
+    },
+    "refetchError": {
+      "title": "❌ Error",
+      "description": "<@{userId}> An error occurred while refetching. Please try again later."
+    }
+  },
+  "fetch": {
+    "maintenanceWindow": "Cannot fetch data during maintenance window (4AM - 7AM JST)",
+    "startError": "An error occurred while starting the fetch. Please try again later.",
+    "initializing": {
+      "title": "🔄 Fetching {regionName} Data",
+      "description": "<@{userId}> Starting data fetch from maimai DX NET...",
+      "status": "📊 Status",
+      "statusValue": "Initializing..."
+    },
+    "error": {
+      "title": "❌ Fetch Error",
+      "description": "<@{userId}> An error occurred while fetching your data: {message}"
+    },
+    "failed": {
+      "title": "❌ Fetch Failed",
+      "description": "<@{userId}> Failed to fetch {regionName} data: {reason}"
+    },
+    "timeout": {
+      "title": "⏰ Fetch Timeout",
+      "description": "<@{userId}> The fetch is taking longer than expected. Please check your data on the website.",
+      "statusName": "🌐 Check Status",
+      "statusValue": "[Visit tomomai ともマイ]({baseUrl}/) to see your latest data!"
+    },
+    "complete": {
+      "title": "✅ Fetch Complete",
+      "description": "<@{userId}> Data fetch completed successfully!"
+    },
+    "generatingImage": {
+      "title": "🔄 Fetching {regionName} Data",
+      "description": "<@{userId}> Data fetch completed, generating profile image...",
+      "status": "📊 Status",
+      "statusValue": "⏳ Generating Profile Image"
+    },
+    "progress": {
+      "title": "🔄 Fetching {regionName} Data",
+      "description": "<@{userId}> Fetching data from maimai DX NET...",
+      "status": "📊 Status"
+    },
+    "albumPreference": {
+      "title": "⚙️ Album Privacy Settings Required",
+      "description": "<@{userId}> Before fetching data, you need to set your album privacy preference.",
+      "whatName": "What is this?",
+      "whatValue": "Albums are images stored with your profile data. You can choose whether to save them or not based on your privacy preferences.",
+      "privacyName": "Privacy Assurance",
+      "privacyValue": "✓ Albums are stored in your private profile\n✓ Not shared publicly unless you make them public\n✓ Only you can see them\n✓ Automatically deleted after 30 days\n✓ You can change this setting anytime",
+      "dontSave": "Don't Save Albums",
+      "save": "Save Albums",
+      "preferenceSet": {
+        "title": "✅ Preference Set",
+        "description": "Your album preference has been set to \"{choice}\". Starting fetch...",
+        "save": "Save Albums",
+        "dontSave": "Don't Save Albums"
+      }
+    }
+  },
+  "profile": {
+    "loading": {
+      "title": "🔄 Loading {regionName} Profile",
+      "description": "<@{userId}> Generating your profile image...",
+      "status": "📊 Status",
+      "statusValue": "⏳ Generating Profile Image"
+    },
+    "error": "An error occurred while fetching your rating. Please try again later.",
+    "content": "<@{userId}> {comment}, you only have **{rating}** rating! 😤{regionSuffix}\n-# New Charts: {newRating} (avg: {newAvg}) - Old Charts: {oldRating} (avg: {oldAvg}) - Stars: {stars} - Total Plays: {totalPlays}",
+    "viewFullProfile": "🔗 View Full Profile"
+  },
+  "recents": {
+    "loading": {
+      "title": "🔄 Loading {regionName} Recent Plays",
+      "description": "<@{userId}> Generating your recent play image...",
+      "status": "📊 Status",
+      "statusValue": "⏳ Generating Image"
+    },
+    "noPlays": {
+      "title": "📊 No Recent Plays Found",
+      "description": "You don't have any recent {regionName} region plays yet!",
+      "noMore": "No more plays found."
+    },
+    "error": {
+      "title": "❌ Error",
+      "description": "Failed to generate image: {message}"
+    },
+    "content": "<@{userId}> Here are your recent plays at <t:{unix}:f> ({regionName})",
+    "newerPlay": "Newer Play",
+    "olderPlay": "Older Play",
+    "errorGeneric": "An error occurred while fetching your recent plays. Please try again later."
+  },
+  "recommend": {
+    "title": "🎯 {regionName} Recommendations",
+    "description": "<@{userId}>\n```\n{body}\n```",
+    "none": {
+      "title": "🎯 {regionName} Recommendations",
+      "description": "<@{userId}> No recommendations — your scores are already optimal!"
+    },
+    "errorGeneric": "An error occurred while generating recommendations. Please try again later.",
+    "errorContent": "An error occurred while generating recommendations. Please try again later."
+  },
+  "daily": {
+    "noPlays": "<@{userId}> No plays found{day} ({regionName}).",
+    "content": "<@{userId}> Daily plays for **{day}** ({regionName})",
+    "failed": "<@{userId}> ❌ Failed to generate daily plays image.",
+    "errorGeneric": "An error occurred while fetching your daily plays. Please try again later.",
+    "play": "play",
+    "plays": "plays"
+  },
+  "invite": {
+    "title": "🎯 Invite tomomai ともマイ",
+    "description": "Add tomomai ともマイ bot to your Discord server to track and share maimai DX scores!",
+    "featuresName": "✨ Features",
+    "featuresValue": "• Track scores across International and Japan regions\n• Import data directly from maimai DX NET\n• View historical progress with snapshots\n• Beautiful score analysis and rating calculations",
+    "addName": "🔗 Add to Server",
+    "addValue": "[Click here to invite the bot]({url})",
+    "websiteName": "🌐 Website"
+  },
+  "regions": {
+    "intl": "International",
+    "jp": "Japan",
+    "cn": "China"
+  },
+  "age": {
+    "justNow": "just now",
+    "minute": "1 minute",
+    "minutes": "{count} minutes",
+    "hour": "1 hour",
+    "hours": "{count} hours",
+    "day": "1 day",
+    "days": "{count} days",
+    "month": "1 month",
+    "months": "{count} months",
+    "year": "1 year",
+    "years": "{count} years"
+  }
+}

--- a/apps/main/messages/discord/en-US.json
+++ b/apps/main/messages/discord/en-US.json
@@ -152,7 +152,8 @@
     "errorContent": "An error occurred while generating recommendations. Please try again later."
   },
   "daily": {
-    "noPlays": "<@{userId}> No plays found{day} ({regionName}).",
+    "noPlays": "<@{userId}> No plays found ({regionName}).",
+    "noPlaysDay": "<@{userId}> No plays found for {day} ({regionName}).",
     "content": "<@{userId}> Daily plays for **{day}** ({regionName})",
     "failed": "<@{userId}> ❌ Failed to generate daily plays image.",
     "errorGeneric": "An error occurred while fetching your daily plays. Please try again later.",

--- a/apps/main/messages/discord/ja.json
+++ b/apps/main/messages/discord/ja.json
@@ -152,7 +152,8 @@
     "errorContent": "おすすめ楽曲の生成中にエラーが発生しました。しばらくしてからもう一度お試しください。"
   },
   "daily": {
-    "noPlays": "<@{userId}> {day} のプレイ記録は見つかりませんでした（{regionName}）。",
+    "noPlays": "<@{userId}> プレイ記録は見つかりませんでした（{regionName}）。",
+    "noPlaysDay": "<@{userId}> {day} のプレイ記録は見つかりませんでした（{regionName}）。",
     "content": "<@{userId}> **{day}** のデイリー記録（{regionName}）",
     "failed": "<@{userId}> ❌ デイリー記録画像の作成に失敗しました。",
     "errorGeneric": "デイリー記録の読み込み中にエラーが発生しました。しばらくしてからもう一度お試しください。",

--- a/apps/main/messages/discord/ja.json
+++ b/apps/main/messages/discord/ja.json
@@ -1,0 +1,189 @@
+{
+  "common": {
+    "footer": "tomomai ともマイ • maimai DX スコア管理BOT",
+    "notRegistered": {
+      "title": "❌ アカウント未連携",
+      "description": "Discordアカウントがまだ tomomai と連携されていません！",
+      "getStarted": {
+        "name": "🔗 はじめよう",
+        "value": "[tomomai ともマイ]({baseUrl}/) にアクセスしてDiscordでログインし、スコア管理を始めましょう！"
+      }
+    },
+    "noData": {
+      "title": "📊 データがありません",
+      "description": "まだ {regionName} のプレイデータが登録されていません。",
+      "import": {
+        "name": "🎯 スコアを同期する",
+        "value": "[tomomai ともマイ]({baseUrl}/) にアクセスして、{regionName} のスコアデータを同期しましょう！"
+      }
+    },
+    "error": {
+      "title": "❌ エラー",
+      "unableToIdentify": "Discordユーザーを特定できませんでした。もう一度お試しください。",
+      "unableToIdentifyShort": "Discordユーザーを特定できません。",
+      "generic": "エラーが発生しました。しばらくしてからもう一度お試しください。",
+      "notAvailableToYou": "❌ このボタンはあなたには使用できません。",
+      "unknownCommand": "無効なコマンドです"
+    },
+    "loading": {
+      "title": "⏳ 読み込み中…",
+      "description": "<@{userId}> 保存されているデータで処理を続行します…"
+    }
+  },
+  "staleness": {
+    "title": "⏳ データ未更新",
+    "description": "<@{userId}> 最後に {regionName} のデータを同期してから **{age}** が経過しています。\n{cmdLine}",
+    "cmdLine": {
+      "profile": "このまま（古いデータで）プロフィールを表示しますか？",
+      "recents": "このまま最近のプレイ記録を表示しますか？",
+      "recommend": "このままおすすめ楽曲を表示しますか？",
+      "daily": "このまま {day} のプレイ記録を作成しますか？",
+      "dailyDefault": "このまま今日のプレイ記録を作成しますか？",
+      "default": "このまま続行しますか？"
+    },
+    "buttons": {
+      "continue": "このまま続行",
+      "refetchAndContinue": "データを更新して続行"
+    },
+    "refetching": {
+      "title": "🔄 {regionName} データを更新中",
+      "description": "<@{userId}> maimai DX NET から最新データを取得しています…"
+    },
+    "refetchError": {
+      "title": "❌ エラー",
+      "description": "<@{userId}> データの更新中にエラーが発生しました。しばらくしてからもう一度お試しください。"
+    }
+  },
+  "fetch": {
+    "maintenanceWindow": "現在メンテナンス時間中（午前4時〜7時）のため、データ同期はできません。",
+    "startError": "データ同期を開始できませんでした。しばらくしてからもう一度お試しください。",
+    "initializing": {
+      "title": "🔄 {regionName} データを同期中",
+      "description": "<@{userId}> maimai DX NET との同期を開始します…",
+      "status": "📊 ステータス",
+      "statusValue": "準備中…"
+    },
+    "error": {
+      "title": "❌ 同期エラー",
+      "description": "<@{userId}> データの同期中にエラーが発生しました：{message}"
+    },
+    "failed": {
+      "title": "❌ 同期失敗",
+      "description": "<@{userId}> {regionName} データの同期に失敗しました：{reason}"
+    },
+    "timeout": {
+      "title": "⏰ タイムアウト",
+      "description": "<@{userId}> データ同期に時間がかかっています。最新の状態はウェブサイトでご確認ください。",
+      "statusName": "🌐 状況を確認",
+      "statusValue": "[tomomai ともマイ]({baseUrl}/) で最新データをご確認ください！"
+    },
+    "complete": {
+      "title": "✅ 同期完了",
+      "description": "<@{userId}> データの同期が完了しました！"
+    },
+    "generatingImage": {
+      "title": "🔄 {regionName} データを同期中",
+      "description": "<@{userId}> データの同期が完了しました。プロフィール画像を作成しています…",
+      "status": "📊 ステータス",
+      "statusValue": "⏳ プロフィール画像を作成中"
+    },
+    "progress": {
+      "title": "🔄 {regionName} データを同期中",
+      "description": "<@{userId}> maimai DX NET からデータを受信しています…",
+      "status": "📊 ステータス"
+    },
+    "albumPreference": {
+      "title": "⚙️ アルバムの公開設定が必要です",
+      "description": "<@{userId}> データを同期する前に、アルバムの保存設定を行ってください。",
+      "whatName": "これは何ですか？",
+      "whatValue": "アルバムはプロフィールデータと一緒に保存される画像（リザルト画面など）です。プライバシーの案内に基づいて、保存の有無を選択できます。",
+      "privacyName": "プライバシーについて",
+      "privacyValue": "✓ アルバムは非公開の状態で保存されます\n✓ ご自身で公開しない限り、他者には見られません\n✓ あなた自身のみが閲覧可能です\n✓ 30日経過後に自動削除されます\n✓ この設定はいつでも変更可能です",
+      "dontSave": "保存しない",
+      "save": "保存する",
+      "preferenceSet": {
+        "title": "✅ 設定完了",
+        "description": "アルバム設定を「{choice}」として保存しました。同期を開始します…",
+        "save": "保存する",
+        "dontSave": "保存しない"
+      }
+    }
+  },
+  "profile": {
+    "loading": {
+      "title": "🔄 {regionName} プロフィールを読み込み中",
+      "description": "<@{userId}> プロフィール画像を作成しています…",
+      "status": "📊 ステータス",
+      "statusValue": "⏳ プロフィール画像を作成中"
+    },
+    "error": "Rating の取得中にエラーが発生しました。しばらくしてからもう一度お試しください。",
+    "content": "<@{userId}> {comment}、あなたの Rating は、たったの **{rating}** です！😤{regionSuffix}\n-# 新曲枠：{newRating}（平均：{newAvg}）- 旧曲枠：{oldRating}（平均：{oldAvg}）- 獲得スター：{stars} - 総プレイ回数：{totalPlays}",
+    "viewFullProfile": "🔗 プロフィール詳細を見る"
+  },
+  "recents": {
+    "loading": {
+      "title": "🔄 {regionName} プレイ記録を読み込み中",
+      "description": "<@{userId}> 最近のプレイ記録の画像を作成しています…",
+      "status": "📊 ステータス",
+      "statusValue": "⏳ 画像を作成中"
+    },
+    "noPlays": {
+      "title": "📊 プレイ記録がありません",
+      "description": "まだ {regionName} のプレイ記録がありません！",
+      "noMore": "これより前の記録は見つかりませんでした。"
+    },
+    "error": {
+      "title": "❌ エラー",
+      "description": "画像の作成に失敗しました：{message}"
+    },
+    "content": "<@{userId}> <t:{unix}:f> 時点のプレイ記録です（{regionName}）",
+    "newerPlay": "新しい記録",
+    "olderPlay": "過去の記録",
+    "errorGeneric": "プレイ記録の読み込み中にエラーが発生しました。しばらくしてからもう一度お試しください。"
+  },
+  "recommend": {
+    "title": "🎯 {regionName} おすすめ楽曲",
+    "description": "<@{userId}>\n```\n{body}\n```",
+    "none": {
+      "title": "🎯 {regionName} おすすめ楽曲",
+      "description": "<@{userId}> おすすめする楽曲はありません — すでに完璧なスコアです！"
+    },
+    "errorGeneric": "おすすめ楽曲の生成中にエラーが発生しました。しばらくしてからもう一度お試しください。",
+    "errorContent": "おすすめ楽曲の生成中にエラーが発生しました。しばらくしてからもう一度お試しください。"
+  },
+  "daily": {
+    "noPlays": "<@{userId}> {day} のプレイ記録は見つかりませんでした（{regionName}）。",
+    "content": "<@{userId}> **{day}** のデイリー記録（{regionName}）",
+    "failed": "<@{userId}> ❌ デイリー記録画像の作成に失敗しました。",
+    "errorGeneric": "デイリー記録の読み込み中にエラーが発生しました。しばらくしてからもう一度お試しください。",
+    "play": "回",
+    "plays": "回"
+  },
+  "invite": {
+    "title": "🎯 tomomai ともマイ をサーバーに招待",
+    "description": "tomomai を Discord サーバーに追加して、maimai DX のスコアを管理・シェアしましょう！",
+    "featuresName": "✨ 主な機能",
+    "featuresValue": "• 日本版・海外版の両リージョンに対応したスコア管理\n• maimai DX NET からの直接データ同期\n• スナップショット機能による過去の成長記録\n• 詳細なスコア分析と Rating 計算",
+    "addName": "🔗 サーバーに追加",
+    "addValue": "[ここをクリックしてbotを招待]({url})",
+    "websiteName": "🌐 ウェブサイト"
+  },
+  "regions": {
+    "intl": "海外",
+    "jp": "日本",
+    "cn": "中国"
+  },
+  "age": {
+    "justNow": "たった今",
+    "minute": "1分",
+    "minutes": "{count}分",
+    "hour": "1時間",
+    "hours": "{count}時間",
+    "day": "1日",
+    "days": "{count}日",
+    "month": "1ヶ月",
+    "months": "{count}ヶ月",
+    "year": "1年",
+    "years": "{count}年"
+  }
+}

--- a/apps/main/messages/discord/ko.json
+++ b/apps/main/messages/discord/ko.json
@@ -152,7 +152,8 @@
     "errorContent": "추천 곡을 분석하는 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요."
   },
   "daily": {
-    "noPlays": "<@{userId}> {day}의 플레이 기록을 찾을 수 없습니다. ({regionName})",
+    "noPlays": "<@{userId}> 플레이 기록을 찾을 수 없습니다. ({regionName})",
+    "noPlaysDay": "<@{userId}> {day}의 플레이 기록을 찾을 수 없습니다. ({regionName})",
     "content": "<@{userId}> **{day}** 일일 플레이 기록 ({regionName})",
     "failed": "<@{userId}> ❌ 일일 플레이 기록 이미지 생성에 실패했습니다.",
     "errorGeneric": "일일 플레이 기록을 불러오는 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.",

--- a/apps/main/messages/discord/ko.json
+++ b/apps/main/messages/discord/ko.json
@@ -1,0 +1,189 @@
+{
+  "common": {
+    "footer": "tomomai ともマイ • maimai DX 성적 관리 봇",
+    "notRegistered": {
+      "title": "❌ 계정 미연동",
+      "description": "아직 Discord 계정이 tomomai와 연동되지 않았어요!",
+      "getStarted": {
+        "name": "🔗 시작하기",
+        "value": "[tomomai ともマイ]({baseUrl}/)에 접속해 Discord로 로그인하고 성적 관리를 시작해 보세요!"
+      }
+    },
+    "noData": {
+      "title": "📊 데이터 없음",
+      "description": "아직 {regionName} 리전의 플레이 데이터가 없습니다.",
+      "import": {
+        "name": "🎯 점수 동기화하기",
+        "value": "[tomomai ともマイ]({baseUrl}/)에 접속하여 {regionName} maimai DX 점수를 동기화해 주세요!"
+      }
+    },
+    "error": {
+      "title": "❌ 오류",
+      "unableToIdentify": "Discord 사용자를 확인할 수 없습니다. 다시 시도해 주세요.",
+      "unableToIdentifyShort": "Discord 사용자를 확인할 수 없습니다.",
+      "generic": "오류가 발생했습니다. 잠시 후 다시 시도해 주세요.",
+      "notAvailableToYou": "❌ 본인만 사용할 수 있는 버튼입니다.",
+      "unknownCommand": "알 수 없는 명령어입니다."
+    },
+    "loading": {
+      "title": "⏳ 로딩 중...",
+      "description": "<@{userId}> 저장된 데이터로 계속 진행합니다..."
+    }
+  },
+  "staleness": {
+    "title": "⏳ 데이터 갱신 필요",
+    "description": "<@{userId}> 마지막으로 **{regionName}** 데이터를 동기화한 지 **{age}**가 지났습니다.\n{cmdLine}",
+    "cmdLine": {
+      "profile": "이대로 프로필을 확인하시겠어요?",
+      "recents": "이대로 최근 플레이 기록을 확인하시겠어요?",
+      "recommend": "이대로 추천 곡을 확인하시겠어요?",
+      "daily": "이대로 {day}의 플레이 기록을 생성하시겠어요?",
+      "dailyDefault": "이대로 오늘의 플레이 기록을 생성하시겠어요?",
+      "default": "이대로 진행하시겠어요?"
+    },
+    "buttons": {
+      "continue": "이대로 계속",
+      "refetchAndContinue": "데이터 갱신 후 계속"
+    },
+    "refetching": {
+      "title": "🔄 {regionName} 데이터 갱신 중",
+      "description": "<@{userId}> maimai DX NET에서 최신 데이터를 가져오고 있습니다..."
+    },
+    "refetchError": {
+      "title": "❌ 오류",
+      "description": "<@{userId}> 데이터를 갱신하는 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요."
+    }
+  },
+  "fetch": {
+    "maintenanceWindow": "서버 점검 시간(한국 시간 오전 4시 ~ 7시)에는 데이터를 갱신할 수 없습니다.",
+    "startError": "데이터 동기화를 시작하지 못했습니다. 잠시 후 다시 시도해 주세요.",
+    "initializing": {
+      "title": "🔄 {regionName} 데이터 동기화 중",
+      "description": "<@{userId}> maimai DX NET과 데이터 동기화를 시작합니다...",
+      "status": "📊 상태",
+      "statusValue": "준비 중..."
+    },
+    "error": {
+      "title": "❌ 동기화 오류",
+      "description": "<@{userId}> 데이터를 동기화하는 중 오류가 발생했습니다: {message}"
+    },
+    "failed": {
+      "title": "❌ 동기화 실패",
+      "description": "<@{userId}> {regionName} 데이터를 동기화하지 못했습니다: {reason}"
+    },
+    "timeout": {
+      "title": "⏰ 처리 지연",
+      "description": "<@{userId}> 데이터 갱신이 예상보다 오래 걸리고 있습니다. 웹사이트에서 최신 상태를 확인해 주세요.",
+      "statusName": "🌐 상태 확인",
+      "statusValue": "[tomomai ともマイ]({baseUrl}/)에서 최신 데이터를 확인하세요!"
+    },
+    "complete": {
+      "title": "✅ 동기화 완료",
+      "description": "<@{userId}> 데이터 동기화가 성공적으로 완료되었습니다!"
+    },
+    "generatingImage": {
+      "title": "🔄 {regionName} 데이터 동기화 중",
+      "description": "<@{userId}> 데이터 동기화 완료! 프로필 이미지를 생성하고 있습니다...",
+      "status": "📊 상태",
+      "statusValue": "⏳ 프로필 이미지 생성 중"
+    },
+    "progress": {
+      "title": "🔄 {regionName} 데이터 동기화 중",
+      "description": "<@{userId}> maimai DX NET에서 데이터를 읽어오는 중...",
+      "status": "📊 상태"
+    },
+    "albumPreference": {
+      "title": "⚙️ 앨범 프라이버시 설정 필요",
+      "description": "<@{userId}> 데이터를 동기화하려면 먼저 앨범 저장 설정을 완료해야 합니다.",
+      "whatName": "이것은 무엇인가요?",
+      "whatValue": "앨범은 리절트 화면 등 프로필 데이터와 함께 저장되는 이미지입니다. 프라이버시 설정에 따라 저장 여부를 직접 선택할 수 있습니다.",
+      "privacyName": "개인정보 보호 안내",
+      "privacyValue": "✓ 앨범은 비공개 상태로 안전하게 저장됩니다.\n✓ 본인이 공개로 변경하지 않는 한 타인에게 노출되지 않습니다.\n✓ 본인만 볼 수 있습니다.\n✓ 30일 후 자동으로 삭제됩니다.\n✓ 설정은 언제든 변경할 수 있습니다.",
+      "dontSave": "앨범 저장하지 않음",
+      "save": "앨범 저장함",
+      "preferenceSet": {
+        "title": "✅ 설정 완료",
+        "description": "앨범 설정이 '{choice}'(으)로 저장되었습니다. 동기화를 시작합니다...",
+        "save": "앨범 저장함",
+        "dontSave": "앨범 저장하지 않음"
+      }
+    }
+  },
+  "profile": {
+    "loading": {
+      "title": "🔄 {regionName} 프로필 불러오는 중",
+      "description": "<@{userId}> 프로필 이미지를 생성하고 있습니다...",
+      "status": "📊 상태",
+      "statusValue": "⏳ 프로필 이미지 생성 중"
+    },
+    "error": "레이팅 정보를 불러오는 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.",
+    "content": "<@{userId}> {comment}! 당신의 레이팅은 겨우 **{rating}**밖에 안 되네요! 😤{regionSuffix}\n-# 신곡: {newRating} (평균: {newAvg}) - 구곡: {oldRating} (평균: {oldAvg}) - 스타: {stars} - 총 플레이: {totalPlays}회",
+    "viewFullProfile": "🔗 전체 프로필 보기"
+  },
+  "recents": {
+    "loading": {
+      "title": "🔄 {regionName} 최근 기록 불러오는 중",
+      "description": "<@{userId}> 최근 플레이 기록 이미지를 생성하고 있습니다...",
+      "status": "📊 상태",
+      "statusValue": "⏳ 이미지 생성 중"
+    },
+    "noPlays": {
+      "title": "📊 플레이 기록 없음",
+      "description": "아직 {regionName} 리전에 최근 플레이 기록이 없습니다!",
+      "noMore": "더 이상 이전 기록이 없습니다."
+    },
+    "error": {
+      "title": "❌ 오류",
+      "description": "이미지를 생성하지 못했습니다: {message}"
+    },
+    "content": "<@{userId}> <t:{unix}:f> 기준 최근 플레이 기록입니다. ({regionName})",
+    "newerPlay": "더 최신 기록",
+    "olderPlay": "이전 기록",
+    "errorGeneric": "최근 플레이 기록을 불러오는 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요."
+  },
+  "recommend": {
+    "title": "🎯 {regionName} 추천 곡",
+    "description": "<@{userId}>\n```\n{body}\n```",
+    "none": {
+      "title": "🎯 {regionName} 추천 곡",
+      "description": "<@{userId}> 추천해드릴 곡이 없습니다 — 이미 너무 완벽한 점수네요!"
+    },
+    "errorGeneric": "추천 곡을 분석하는 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.",
+    "errorContent": "추천 곡을 분석하는 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요."
+  },
+  "daily": {
+    "noPlays": "<@{userId}> {day}의 플레이 기록을 찾을 수 없습니다. ({regionName})",
+    "content": "<@{userId}> **{day}** 일일 플레이 기록 ({regionName})",
+    "failed": "<@{userId}> ❌ 일일 플레이 기록 이미지 생성에 실패했습니다.",
+    "errorGeneric": "일일 플레이 기록을 불러오는 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.",
+    "play": "회",
+    "plays": "회"
+  },
+  "invite": {
+    "title": "🎯 tomomai ともマイ 초대하기",
+    "description": "tomomai 봇을 Discord 서버에 추가하고 maimai DX 친구들과 성적을 공유해 보세요!",
+    "featuresName": "✨ 주요 기능",
+    "featuresValue": "• 글로벌 및 일본 서버 성적 완벽 지원\n• maimai DX NET에서 데이터 직접 동기화\n• 스냅샷 기능으로 과거 성장 기록 확인\n• 깔끔한 성적 분석 및 레이팅(상수) 계산",
+    "addName": "🔗 서버에 봇 추가",
+    "addValue": "[여기를 눌러 봇을 초대하세요]({url})",
+    "websiteName": "🌐 웹사이트"
+  },
+  "regions": {
+    "intl": "해외",
+    "jp": "일본",
+    "cn": "중국"
+  },
+  "age": {
+    "justNow": "방금 전",
+    "minute": "1분 됨",
+    "minutes": "{count}분",
+    "hour": "1시간 됨",
+    "hours": "{count}시간",
+    "day": "1일 됨",
+    "days": "{count}일",
+    "month": "1개월 됨",
+    "months": "{count}개월",
+    "year": "1년 됨",
+    "years": "{count}년"
+  }
+}

--- a/apps/main/messages/discord/zh-CN.json
+++ b/apps/main/messages/discord/zh-CN.json
@@ -152,7 +152,8 @@
     "errorContent": "推荐算法开小差了，请稍候再试。"
   },
   "daily": {
-    "noPlays": "<@{userId}> 找不到 {day} 的出勤记录喔（{regionName}）。",
+    "noPlays": "<@{userId}> 找不到出勤记录喔（{regionName}）。",
+    "noPlaysDay": "<@{userId}> 找不到 {day} 的出勤记录喔（{regionName}）。",
     "content": "<@{userId}> 这是你 **{day}** 的每日出勤记录（{regionName}）：",
     "failed": "<@{userId}> ❌ 图片生成失败，看不到每日游玩了。",
     "errorGeneric": "拉取每日游玩记录时出错了，请稍后再试。",

--- a/apps/main/messages/discord/zh-CN.json
+++ b/apps/main/messages/discord/zh-CN.json
@@ -1,0 +1,189 @@
+{
+  "common": {
+    "footer": "tomomai ともマイ • maimai DX 查分器",
+    "notRegistered": {
+      "title": "❌ 未绑定",
+      "description": "你的 Discord 账号还没有绑定 tomomai 喔！",
+      "getStarted": {
+        "name": "🔗 开始使用",
+        "value": "[前往 tomomai ともマイ]({baseUrl}/) 使用 Discord 登录，开始管理你的成绩吧！"
+      }
+    },
+    "noData": {
+      "title": "📊 暂无数据",
+      "description": "系统里还没有你 {regionName} 的游玩数据！",
+      "import": {
+        "name": "🎯 同步成绩",
+        "value": "[前往 tomomai ともマイ]({baseUrl}/) 即可一键同步你的 {regionName} maimai DX 成绩！"
+      }
+    },
+    "error": {
+      "title": "❌ 发生错误",
+      "unableToIdentify": "无法识别 Discord 用户，请稍后重试。",
+      "unableToIdentifyShort": "无法识别 Discord 用户。",
+      "generic": "出错了，请稍后再试一次哦。",
+      "notAvailableToYou": "❌ 你无权操作此按钮。",
+      "unknownCommand": "未知的无效指令"
+    },
+    "loading": {
+      "title": "⏳ 正在加载...",
+      "description": "<@{userId}> 正在使用现有的缓存数据继续操作..."
+    }
+  },
+  "staleness": {
+    "title": "⏳ 数据较旧",
+    "description": "<@{userId}> 距离你上次同步 **{regionName}** 的数据已经过去了 **{age}** 啦。\n{cmdLine}",
+    "cmdLine": {
+      "profile": "确定要直接查看旧版的个人名片吗？",
+      "recents": "确定要直接查看旧版的游玩记录吗？",
+      "recommend": "确定要直接基于旧版数据查看推荐吗？",
+      "daily": "确定要直接生成 {day} 的游玩记录吗？",
+      "dailyDefault": "确定要生成今日的游玩记录吗？",
+      "default": "是否继续操作？"
+    },
+    "buttons": {
+      "continue": "仍然继续",
+      "refetchAndContinue": "重新同步并查看"
+    },
+    "refetching": {
+      "title": "🔄 正在更新 {regionName} 数据",
+      "description": "<@{userId}> 正在向 maimai DX NET 请求最新数据，请稍后..."
+    },
+    "refetchError": {
+      "title": "❌ 同步失败",
+      "description": "<@{userId}> 重新同步数据时出了点状况，请稍后再试。"
+    }
+  },
+  "fetch": {
+    "maintenanceWindow": "现在是服务器维护时段（北京时间凌晨 3 点至 6 点），暂时无法同步数据喔。",
+    "startError": "启动数据同步失败，请稍候重试。",
+    "initializing": {
+      "title": "🔄 正在同步 {regionName} 数据",
+      "description": "<@{userId}> 正在连接 maimai DX NET 准备同步数据...",
+      "status": "📊 状态",
+      "statusValue": "初始化中..."
+    },
+    "error": {
+      "title": "❌ 同步出错",
+      "description": "<@{userId}> 同步数据时发生错误：{message}"
+    },
+    "failed": {
+      "title": "❌ 同步失败",
+      "description": "<@{userId}> 获取 {regionName} 数据失败：{reason}"
+    },
+    "timeout": {
+      "title": "⏰ 同步超时",
+      "description": "<@{userId}> 这次同步耗时稍微久了些，可以直接前往网页版确认最新数据哦。",
+      "statusName": "🌐 查看最新状态",
+      "statusValue": "[前往 tomomai ともマイ]({baseUrl}/) 查看你的最新面板！"
+    },
+    "complete": {
+      "title": "✅ 同步完成",
+      "description": "<@{userId}> 你的游玩数据已成功更新！"
+    },
+    "generatingImage": {
+      "title": "🔄 正在同步 {regionName} 数据",
+      "description": "<@{userId}> 数据同步完毕！正在为你绘制个人名片...",
+      "status": "📊 状态",
+      "statusValue": "⏳ 正在生成个人名片"
+    },
+    "progress": {
+      "title": "🔄 正在同步 {regionName} 数据",
+      "description": "<@{userId}> 正在从 maimai DX NET 努力拉取数据中...",
+      "status": "📊 状态"
+    },
+    "albumPreference": {
+      "title": "⚙️ 需先设置相册隐私",
+      "description": "<@{userId}> 在同步数据前，请先告诉我是否需要保存你的结算截图（相册）。",
+      "whatName": "这是什么意思？",
+      "whatValue": "相册是指与你成绩数据一起保存的游戏内结算截图。你可以基于隐私考虑，决定本 Bot 是否要保存它们。",
+      "privacyName": "隐私保护说明",
+      "privacyValue": "✓ 相册默认保存在你的私密名片夹中\n✓ 除非你主动开启公开，否则仅自己可见\n✓ 服务器会在 30 天后自动清理图片\n✓ 你随时可以回来更改本项设置",
+      "dontSave": "不保存相册",
+      "save": "保存相册",
+      "preferenceSet": {
+        "title": "✅ 设置成功",
+        "description": "已将你的相册偏好保存为“{choice}”。开始拉取数据...",
+        "save": "保存相册",
+        "dontSave": "不保存相册"
+      }
+    }
+  },
+  "profile": {
+    "loading": {
+      "title": "🔄 正在加载 {regionName} 玩家名片",
+      "description": "<@{userId}> 正在生成你的个人名片，马上就好...",
+      "status": "📊 状态",
+      "statusValue": "⏳ 生成名片中"
+    },
+    "error": "获取你的 Rating 时卡住了，请稍后再查一下。",
+    "content": "<@{userId}> {comment}，你的 Rating 居然只有 **{rating}** 吗！😤{regionSuffix}\n-# 新谱：{newRating}（平均：{newAvg}）- 旧谱：{oldRating}（平均：{oldAvg}）- 星星数：{stars} - 总游玩：{totalPlays} 局",
+    "viewFullProfile": "🔗 网页版查看详细数据"
+  },
+  "recents": {
+    "loading": {
+      "title": "🔄 正在加载 {regionName} 游玩记录",
+      "description": "<@{userId}> 正在整理并生成游玩记录图片...",
+      "status": "📊 状态",
+      "statusValue": "⏳ 正在排版生成..."
+    },
+    "noPlays": {
+      "title": "📊 暂无游玩记录",
+      "description": "目前找不到你在 {regionName} 的任何出勤记录哦！",
+      "noMore": "太久远啦，翻不到更多记录了。"
+    },
+    "error": {
+      "title": "❌ 发生错误",
+      "description": "生成记录图片失败：{message}"
+    },
+    "content": "<@{userId}> 这是你 <t:{unix}:f> 的出勤记录（{regionName}）：",
+    "newerPlay": "更近一条",
+    "olderPlay": "更早一条",
+    "errorGeneric": "加载游玩记录时出错了，请稍候再试。"
+  },
+  "recommend": {
+    "title": "🎯 {regionName} 推分建议",
+    "description": "<@{userId}>\n```\n{body}\n```",
+    "none": {
+      "title": "🎯 {regionName} 推分建议",
+      "description": "<@{userId}> 暂无推分建议 — 你的底分水平已经练得炉火纯青啦！"
+    },
+    "errorGeneric": "生成推荐乐曲时发生错误，稍后重试一下吧。",
+    "errorContent": "推荐算法开小差了，请稍候再试。"
+  },
+  "daily": {
+    "noPlays": "<@{userId}> 找不到 {day} 的出勤记录喔（{regionName}）。",
+    "content": "<@{userId}> 这是你 **{day}** 的每日出勤记录（{regionName}）：",
+    "failed": "<@{userId}> ❌ 图片生成失败，看不到每日游玩了。",
+    "errorGeneric": "拉取每日游玩记录时出错了，请稍后再试。",
+    "play": "局",
+    "plays": "局"
+  },
+  "invite": {
+    "title": "🎯 邀请 tomomai ともマイ 加入频道",
+    "description": "把 tomomai 加入你的 Discord 服务器，和群友一起轻松查分、分享 maimai DX 成绩！",
+    "featuresName": "✨ 功能亮点",
+    "featuresValue": "• 完美支持 国际服/日服 双区服数据同步\n• 免密直连，安全从 maimai DX NET 获取成绩\n• 支持数据快照分析，见证你的推分历程\n• 详细的底分与定数分析面板",
+    "addName": "🔗 邀请到服务器",
+    "addValue": "[点击这里一键邀请 Bot 进群]({url})",
+    "websiteName": "🌐 官方网站"
+  },
+  "regions": {
+    "intl": "国际服",
+    "jp": "日服",
+    "cn": "国服"
+  },
+  "age": {
+    "justNow": "刚刚",
+    "minute": "1 分钟",
+    "minutes": "{count} 分钟",
+    "hour": "1 小时",
+    "hours": "{count} 小时",
+    "day": "1 天",
+    "days": "{count} 天",
+    "month": "1 个月",
+    "months": "{count} 个月",
+    "year": "1 年",
+    "years": "{count} 年"
+  }
+}

--- a/apps/main/messages/discord/zh-TW.json
+++ b/apps/main/messages/discord/zh-TW.json
@@ -1,0 +1,189 @@
+{
+  "common": {
+    "footer": "tomomai ともマイ • maimai DX 查分器",
+    "notRegistered": {
+      "title": "❌ 尚未綁定",
+      "description": "你的 Discord 帳號還沒有綁定 tomomai 喔！",
+      "getStarted": {
+        "name": "🔗 開始使用",
+        "value": "[前往 tomomai ともマイ]({baseUrl}/) 以 Discord 登入，開始管理你的成績吧！"
+      }
+    },
+    "noData": {
+      "title": "📊 查無資料",
+      "description": "系統裡面還沒有你 {regionName} 的遊玩資料！",
+      "import": {
+        "name": "🎯 同步成績",
+        "value": "[前往 tomomai ともマイ]({baseUrl}/) 一鍵同步你的 {regionName} maimai DX 成績！"
+      }
+    },
+    "error": {
+      "title": "❌ 發生錯誤",
+      "unableToIdentify": "無法驗證 Discord 使用者，請稍後再試。",
+      "unableToIdentifyShort": "無法驗證 Discord 使用者。",
+      "generic": "出錯了，請稍後再試一次。",
+      "notAvailableToYou": "❌ 這是專屬別人的按鈕，你無法操作。",
+      "unknownCommand": "未知的無效指令"
+    },
+    "loading": {
+      "title": "⏳ 正在載入……",
+      "description": "<@{userId}> 正在使用原有的快取資料繼續……"
+    }
+  },
+  "staleness": {
+    "title": "⏳ 資料未更新",
+    "description": "<@{userId}> 距離你上次同步 **{regionName}** 的資料已經過 **{age}** 囉。\n{cmdLine}",
+    "cmdLine": {
+      "profile": "確定要直接查看舊版的個人名片嗎？",
+      "recents": "確定要直接查看舊版的遊玩紀錄嗎？",
+      "recommend": "確定要基於舊版資料查看推薦嗎？",
+      "daily": "確定要直接產生 {day} 的遊玩紀錄嗎？",
+      "dailyDefault": "確定要直接產生今日的遊玩紀錄嗎？",
+      "default": "確定要繼續嗎？"
+    },
+    "buttons": {
+      "continue": "仍然繼續",
+      "refetchAndContinue": "重新同步並查看"
+    },
+    "refetching": {
+      "title": "🔄 正在更新 {regionName} 資料",
+      "description": "<@{userId}> 正在向 maimai DX NET 請求最新資料，請稍等……"
+    },
+    "refetchError": {
+      "title": "❌ 同步錯誤",
+      "description": "<@{userId}> 資料重新同步時出了點狀況，請稍後再試。"
+    }
+  },
+  "fetch": {
+    "maintenanceWindow": "目前是伺服器維護時段（台灣/香港時間凌晨 3 點至 6 點），暫時無法同步資料喔。",
+    "startError": "啟動資料同步時失敗，請稍候重試。",
+    "initializing": {
+      "title": "🔄 正在同步 {regionName} 資料",
+      "description": "<@{userId}> 正在連線 maimai DX NET 準備同步……",
+      "status": "📊 狀態",
+      "statusValue": "初始化中……"
+    },
+    "error": {
+      "title": "❌ 同步發生錯誤",
+      "description": "<@{userId}> 同步資料時發生錯誤：{message}"
+    },
+    "failed": {
+      "title": "❌ 同步失敗",
+      "description": "<@{userId}> 取得 {regionName} 資料失敗：{reason}"
+    },
+    "timeout": {
+      "title": "⏰ 同步逾時",
+      "description": "<@{userId}> 這次資料同步花了比較多時間，建議直接前往網站查看最新狀態。",
+      "statusName": "🌐 查看網頁狀態",
+      "statusValue": "[前往 tomomai ともマイ]({baseUrl}/) 確認你的最新面板！"
+    },
+    "complete": {
+      "title": "✅ 同步完成",
+      "description": "<@{userId}> 你的遊玩資料已經成功更新囉！"
+    },
+    "generatingImage": {
+      "title": "🔄 正在同步 {regionName} 資料",
+      "description": "<@{userId}> 資料同步完畢！正在為你繪製個人名片……",
+      "status": "📊 狀態",
+      "statusValue": "⏳ 正在產生名片"
+    },
+    "progress": {
+      "title": "🔄 正在同步 {regionName} 資料",
+      "description": "<@{userId}> 正在從 maimai DX NET 拉取資料中……",
+      "status": "📊 狀態"
+    },
+    "albumPreference": {
+      "title": "⚙️ 需先設定相簿隱私",
+      "description": "<@{userId}> 在同步資料前，請先告訴我是否需要保存你的遊玩截圖（相簿）。",
+      "whatName": "這是什麼？",
+      "whatValue": "相簿是跟成績一起保存的遊戲結算畫面。你可以基於隱私考量，決定 Bot 是否該保留它們。",
+      "privacyName": "隱私聲明",
+      "privacyValue": "✓ 相簿預設保存在你私人的檔案中\n✓ 除非你主動公開，否則只有你能看見\n✓ 伺服器會在 30 天後自動刪除圖片\n✓ 你隨時可以回來更改這項設定",
+      "dontSave": "不保存相簿",
+      "save": "保存相簿",
+      "preferenceSet": {
+        "title": "✅ 設定完成",
+        "description": "已將你的相簿偏好設定為「{choice}」。開始取得資料……",
+        "save": "保存相簿",
+        "dontSave": "不保存相簿"
+      }
+    }
+  },
+  "profile": {
+    "loading": {
+      "title": "🔄 正在載入 {regionName} 玩家名片",
+      "description": "<@{userId}> 正在產生你的個人名片，馬上就好……",
+      "status": "📊 狀態",
+      "statusValue": "⏳ 產生名片中"
+    },
+    "error": "讀取你的 Rating 數值卡住了，請稍後再查一下。",
+    "content": "<@{userId}> {comment}，你的 Rating 居然只有 **{rating}** 嗎！😤{regionSuffix}\n-# 新譜：{newRating}（平均：{newAvg}）- 舊譜：{oldRating}（平均：{oldAvg}）- 星星數：{stars} - 總遊玩：{totalPlays} 局",
+    "viewFullProfile": "🔗 查看網頁版完整名片"
+  },
+  "recents": {
+    "loading": {
+      "title": "🔄 正在載入 {regionName} 遊玩紀錄",
+      "description": "<@{userId}> 正在排版並產出出勤紀錄圖片……",
+      "status": "📊 狀態",
+      "statusValue": "⏳ 正在產生中"
+    },
+    "noPlays": {
+      "title": "📊 找不到遊玩紀錄",
+      "description": "目前找不到你在 {regionName} 地區的任何出勤紀錄喔！",
+      "noMore": "已經是極限了，翻不到更舊的紀錄囉。"
+    },
+    "error": {
+      "title": "❌ 發生錯誤",
+      "description": "產生紀錄圖片失敗：{message}"
+    },
+    "content": "<@{userId}> 這是你 <t:{unix}:f> 的出勤紀錄（{regionName}）：",
+    "newerPlay": "較新的紀錄",
+    "olderPlay": "較舊的紀錄",
+    "errorGeneric": "讀取遊玩紀錄時出錯了，請稍候再試。"
+  },
+  "recommend": {
+    "title": "🎯 {regionName} 推分建議",
+    "description": "<@{userId}>\n```\n{body}\n```",
+    "none": {
+      "title": "🎯 {regionName} 推分建議",
+      "description": "<@{userId}> 目前沒有推分建議 — 你的技術已經練到爐火純青啦！"
+    },
+    "errorGeneric": "產生推薦清單時發生錯誤，稍後重新嘗試看看。",
+    "errorContent": "推薦演算法開小差了，請稍候再試。"
+  },
+  "daily": {
+    "noPlays": "<@{userId}> 找不到 {day} 的遊玩紀錄喔（{regionName}）。",
+    "content": "<@{userId}> 這是你 **{day}** 的每日出勤紀錄（{regionName}）：",
+    "failed": "<@{userId}> ❌ 產生每日遊玩圖片失敗了。",
+    "errorGeneric": "讀取每日出勤紀錄時出錯，請稍後再試。",
+    "play": "局",
+    "plays": "局"
+  },
+  "invite": {
+    "title": "🎯 邀請 tomomai ともマイ 加入伺服器",
+    "description": "把 tomomai 帶到你的 Discord 頻道，跟朋友們一起輕鬆查分與分享 maimai DX 紀錄！",
+    "featuresName": "✨ 功能亮點",
+    "featuresValue": "• 完美支援國際版與日本版雙伺服器的成績同步\n• 安全直連，直接從 maimai DX NET 更新成績\n• 擁有資料快照功能，讓你回顧成長歷程\n• 詳細的定數分析與 Rating 結算面板",
+    "addName": "🔗 一鍵加入伺服器",
+    "addValue": "[點擊這裡邀請 Bot 加入]({url})",
+    "websiteName": "🌐 官方網站"
+  },
+  "regions": {
+    "intl": "國際版",
+    "jp": "日本版",
+    "cn": "中國版"
+  },
+  "age": {
+    "justNow": "剛剛",
+    "minute": "1 分鐘",
+    "minutes": "{count} 分鐘",
+    "hour": "1 小時",
+    "hours": "{count} 小時",
+    "day": "1 天",
+    "days": "{count} 天",
+    "month": "1 個月",
+    "months": "{count} 個月",
+    "year": "1 年",
+    "years": "{count} 年"
+  }
+}

--- a/apps/main/messages/discord/zh-TW.json
+++ b/apps/main/messages/discord/zh-TW.json
@@ -152,7 +152,8 @@
     "errorContent": "推薦演算法開小差了，請稍候再試。"
   },
   "daily": {
-    "noPlays": "<@{userId}> 找不到 {day} 的遊玩紀錄喔（{regionName}）。",
+    "noPlays": "<@{userId}> 找不到遊玩紀錄喔（{regionName}）。",
+    "noPlaysDay": "<@{userId}> 找不到 {day} 的遊玩紀錄喔（{regionName}）。",
     "content": "<@{userId}> 這是你 **{day}** 的每日出勤紀錄（{regionName}）：",
     "failed": "<@{userId}> ❌ 產生每日遊玩圖片失敗了。",
     "errorGeneric": "讀取每日出勤紀錄時出錯，請稍後再試。",

--- a/apps/main/scripts/register-discord-commands.js
+++ b/apps/main/scripts/register-discord-commands.js
@@ -32,6 +32,14 @@ const regionOption = {
   choices: enabledRegions.map(r => ({ name: REGION_LABELS[r] ?? r, value: r })),
 };
 
+// Shared optional `fetch` option. When true, force a refetch before running.
+const fetchOption = {
+  type: 5, // BOOLEAN
+  name: 'fetch',
+  description: 'Force a refetch from maimai DX NET before running this command.',
+  required: false,
+};
+
 // Define the commands to register
 const commands = [
   {
@@ -41,7 +49,7 @@ const commands = [
   {
     name: 'profile',
     description: 'Show your latest maimai rating',
-    options: [regionOption],
+    options: [regionOption, fetchOption],
   },
   {
     name: 'fetch',
@@ -51,18 +59,19 @@ const commands = [
   {
     name: 'recents',
     description: 'Show your most recent play',
-    options: [regionOption],
+    options: [regionOption, fetchOption],
   },
   {
     name: 'recommend',
     description: 'Show song recommendations to improve your rating',
-    options: [regionOption],
+    options: [regionOption, fetchOption],
   },
   {
     name: 'daily',
     description: 'Show your plays from a single JST day',
     options: [
       regionOption,
+      fetchOption,
       {
         type: 3,
         name: 'date',

--- a/apps/main/src/app/api/interactions/route.ts
+++ b/apps/main/src/app/api/interactions/route.ts
@@ -5,6 +5,7 @@ import {
   InteractionResponseType,
 } from 'discord-interactions';
 import { handleCommand, handleComponents, handleAutocomplete, createPongResponse } from '@/lib/discord';
+import { t } from '@/lib/discord/i18n';
 import { flushLogger } from '@/lib/logger';
 import { requestLogger } from '@/lib/request-logger';
 
@@ -51,6 +52,7 @@ export async function POST(request: NextRequest) {
         discordUserId,
         applicationId: APPLICATION_ID,
         interactionToken: interaction.token,
+        locale: interaction.locale,
       });
 
       return Response.json(response);
@@ -65,6 +67,7 @@ export async function POST(request: NextRequest) {
         commandName: data.name,
         options: data.options,
         discordUserId,
+        locale: interaction.locale,
       });
 
       return Response.json(response);
@@ -80,6 +83,7 @@ export async function POST(request: NextRequest) {
         discordUserId,
         applicationId: APPLICATION_ID,
         interactionToken: interaction.token,
+        locale: interaction.locale,
       });
 
       if (!response) {
@@ -87,7 +91,7 @@ export async function POST(request: NextRequest) {
         return Response.json({
           type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
           data: {
-            content: '❌ This button is not available to you.',
+            content: t(interaction.locale, 'common.error.notAvailableToYou'),
             flags: 64, // EPHEMERAL
           },
         });

--- a/apps/main/src/lib/discord/commands.ts
+++ b/apps/main/src/lib/discord/commands.ts
@@ -10,7 +10,7 @@ import type { Region } from '@/lib/types';
 import type { StaleCommand } from './staleness';
 import { handleStalenessChoice } from './commands/staleness';
 
-type CommandOption = { name: string; value?: string; type: number; focused?: boolean };
+type CommandOption = { name: string; value?: string | boolean; type: number; focused?: boolean };
 
 // Command definitions. Each data command defaults to the user's selected
 // region and accepts an optional `region` option to override it.
@@ -48,7 +48,7 @@ function getRegionParam(options?: CommandOption[]): string | undefined {
 
 function getBooleanParam(options: CommandOption[] | undefined, name: string): boolean {
   const value = options?.find(o => o.name === name)?.value;
-  return value === 'true';
+  return value === true || value === 'true';
 }
 
 export interface CommandContext {

--- a/apps/main/src/lib/discord/commands.ts
+++ b/apps/main/src/lib/discord/commands.ts
@@ -7,6 +7,8 @@ import { handleAlbumPreferenceSelection } from './commands/album-preference';
 import { handleDailyCommand, handleDailyAutocomplete } from './commands/daily';
 import { createUnknownCommandResponse, DiscordResponse } from './responses';
 import type { Region } from '@/lib/types';
+import type { StaleCommand } from './staleness';
+import { handleStalenessChoice } from './commands/staleness';
 
 type CommandOption = { name: string; value?: string; type: number; focused?: boolean };
 
@@ -44,12 +46,18 @@ function getRegionParam(options?: CommandOption[]): string | undefined {
   return typeof value === 'string' && value.length > 0 ? value : undefined;
 }
 
+function getBooleanParam(options: CommandOption[] | undefined, name: string): boolean {
+  const value = options?.find(o => o.name === name)?.value;
+  return value === 'true';
+}
+
 export interface CommandContext {
   commandName: string;
   options?: CommandOption[];
   discordUserId?: string;
   applicationId: string;
   interactionToken: string;
+  forceFetch?: boolean;
 }
 
 export interface ComponentContext {
@@ -66,9 +74,10 @@ export interface AutocompleteContext {
 }
 
 export async function handleCommand(context: CommandContext): Promise<DiscordResponse> {
-  const { commandName, options, discordUserId, applicationId, interactionToken } = context;
+  const { commandName, options, discordUserId, applicationId, interactionToken, forceFetch } = context;
 
   const regionParam = getRegionParam(options);
+  const forceFetchParam = forceFetch ?? getBooleanParam(options, 'fetch');
 
   switch (commandName.toLowerCase()) {
     case COMMANDS.PROFILE.name.toLowerCase():
@@ -79,7 +88,8 @@ export async function handleCommand(context: CommandContext): Promise<DiscordRes
         discordUserId,
         regionParam,
         applicationId,
-        interactionToken
+        interactionToken,
+        forceFetch: forceFetchParam,
       });
 
     case COMMANDS.FETCH.name.toLowerCase():
@@ -92,6 +102,7 @@ export async function handleCommand(context: CommandContext): Promise<DiscordRes
         applicationId,
         interactionToken
       });
+      // /fetch ignores the `fetch` boolean option on purpose.
 
     case COMMANDS.RECENTS.name.toLowerCase():
       if (!discordUserId) {
@@ -101,7 +112,8 @@ export async function handleCommand(context: CommandContext): Promise<DiscordRes
         discordUserId,
         regionParam,
         applicationId,
-        interactionToken
+        interactionToken,
+        forceFetch: forceFetchParam,
       });
 
     case COMMANDS.RECOMMEND.name.toLowerCase():
@@ -112,7 +124,8 @@ export async function handleCommand(context: CommandContext): Promise<DiscordRes
         discordUserId,
         regionParam,
         applicationId,
-        interactionToken
+        interactionToken,
+        forceFetch: forceFetchParam,
       });
 
     case COMMANDS.DAILY.name.toLowerCase():
@@ -129,6 +142,7 @@ export async function handleCommand(context: CommandContext): Promise<DiscordRes
         day,
         applicationId,
         interactionToken,
+        forceFetch: forceFetchParam,
       });
 
     case COMMANDS.INVITE.name.toLowerCase():
@@ -199,6 +213,34 @@ export async function handleComponents(context: ComponentContext): Promise<Disco
         discordUserId,
         region,
         fetchUseAlbums,
+        applicationId,
+        interactionToken,
+      });
+    }
+  }
+
+  // Parse the custom_id: staleness_<cmd>_<userId>_<region>_<choice>_<payload>
+  if (customId.startsWith('staleness_')) {
+    const parts = customId.split('_');
+    // staleness _ cmd _ userId _ region _ choice _ payload(payload may be empty)
+    if (parts.length >= 6) {
+      const cmd = parts[1];
+      const buttonUserId = parts[2];
+      const region = parts[3] as Region;
+      const refetch = parts[4] === '1';
+      const payload = parts.slice(5).join('_');
+
+      // verify the user clicking is the same as the user who initiated the command
+      if (!discordUserId || discordUserId !== buttonUserId) {
+        return null;
+      }
+
+      return handleStalenessChoice({
+        command: cmd as StaleCommand,
+        discordUserId,
+        region,
+        refetch,
+        payload,
         applicationId,
         interactionToken,
       });

--- a/apps/main/src/lib/discord/commands.ts
+++ b/apps/main/src/lib/discord/commands.ts
@@ -58,6 +58,7 @@ export interface CommandContext {
   applicationId: string;
   interactionToken: string;
   forceFetch?: boolean;
+  locale?: string;
 }
 
 export interface ComponentContext {
@@ -65,16 +66,18 @@ export interface ComponentContext {
   discordUserId?: string;
   applicationId: string;
   interactionToken: string;
+  locale?: string;
 }
 
 export interface AutocompleteContext {
   commandName: string;
   options?: CommandOption[];
   discordUserId?: string;
+  locale?: string;
 }
 
 export async function handleCommand(context: CommandContext): Promise<DiscordResponse> {
-  const { commandName, options, discordUserId, applicationId, interactionToken, forceFetch } = context;
+  const { commandName, options, discordUserId, applicationId, interactionToken, forceFetch, locale } = context;
 
   const regionParam = getRegionParam(options);
   const forceFetchParam = forceFetch ?? getBooleanParam(options, 'fetch');
@@ -90,6 +93,7 @@ export async function handleCommand(context: CommandContext): Promise<DiscordRes
         applicationId,
         interactionToken,
         forceFetch: forceFetchParam,
+        locale,
       });
 
     case COMMANDS.FETCH.name.toLowerCase():
@@ -100,7 +104,8 @@ export async function handleCommand(context: CommandContext): Promise<DiscordRes
         discordUserId,
         regionParam,
         applicationId,
-        interactionToken
+        interactionToken,
+        locale,
       });
       // /fetch ignores the `fetch` boolean option on purpose.
 
@@ -114,6 +119,7 @@ export async function handleCommand(context: CommandContext): Promise<DiscordRes
         applicationId,
         interactionToken,
         forceFetch: forceFetchParam,
+        locale,
       });
 
     case COMMANDS.RECOMMEND.name.toLowerCase():
@@ -126,6 +132,7 @@ export async function handleCommand(context: CommandContext): Promise<DiscordRes
         applicationId,
         interactionToken,
         forceFetch: forceFetchParam,
+        locale,
       });
 
     case COMMANDS.DAILY.name.toLowerCase():
@@ -143,10 +150,11 @@ export async function handleCommand(context: CommandContext): Promise<DiscordRes
         applicationId,
         interactionToken,
         forceFetch: forceFetchParam,
+        locale,
       });
 
     case COMMANDS.INVITE.name.toLowerCase():
-      return handleInviteCommand({ applicationId });
+      return handleInviteCommand({ applicationId, locale });
 
     default:
       return createUnknownCommandResponse();
@@ -154,14 +162,14 @@ export async function handleCommand(context: CommandContext): Promise<DiscordRes
 }
 
 export async function handleAutocomplete(context: AutocompleteContext): Promise<DiscordResponse> {
-  const { commandName, options, discordUserId } = context;
+  const { commandName, options, discordUserId, locale } = context;
 
   switch (commandName.toLowerCase()) {
     case COMMANDS.DAILY.name.toLowerCase(): {
       const regionParam = getRegionParam(options);
       const focused = options?.find(o => o.focused) ?? options?.find(o => o.name === 'date');
       const focusedValue = typeof focused?.value === 'string' ? focused.value : '';
-      return handleDailyAutocomplete({ discordUserId, regionParam, focusedValue });
+      return handleDailyAutocomplete({ discordUserId, regionParam, focusedValue, locale });
     }
     default:
       return { type: 8, data: { choices: [] } };
@@ -169,7 +177,7 @@ export async function handleAutocomplete(context: AutocompleteContext): Promise<
 }
 
 export async function handleComponents(context: ComponentContext): Promise<DiscordResponse | null> {
-  const { customId, discordUserId, applicationId, interactionToken } = context;
+  const { customId, discordUserId, applicationId, interactionToken, locale } = context;
 
   // Parse the custom_id: recents_<userId>_<region>_<skip>
   if (customId.startsWith('recents_')) {
@@ -190,6 +198,7 @@ export async function handleComponents(context: ComponentContext): Promise<Disco
         applicationId,
         interactionToken,
         skip,
+        locale,
       });
     }
   }
@@ -215,6 +224,7 @@ export async function handleComponents(context: ComponentContext): Promise<Disco
         fetchUseAlbums,
         applicationId,
         interactionToken,
+        locale,
       });
     }
   }
@@ -243,6 +253,7 @@ export async function handleComponents(context: ComponentContext): Promise<Disco
         payload,
         applicationId,
         interactionToken,
+        locale,
       });
     }
   }

--- a/apps/main/src/lib/discord/commands/album-preference.ts
+++ b/apps/main/src/lib/discord/commands/album-preference.ts
@@ -4,6 +4,7 @@ import { getLogger } from '@/lib/request-logger';
 import { and, eq } from 'drizzle-orm';
 import { waitUntil } from '@vercel/functions';
 import { DiscordResponse, editDiscordMessage, DISCORD_COLORS, createDeferredResponse } from '../responses';
+import { t } from '../i18n';
 import { handleFetchCommand } from './fetch';
 import type { Region } from '@/lib/types';
 
@@ -13,6 +14,7 @@ export interface AlbumPreferenceOptions {
   fetchUseAlbums: boolean;
   applicationId: string;
   interactionToken: string;
+  locale?: string;
 }
 
 export async function handleAlbumPreferenceSelection({
@@ -21,6 +23,7 @@ export async function handleAlbumPreferenceSelection({
   fetchUseAlbums,
   applicationId,
   interactionToken,
+  locale,
 }: AlbumPreferenceOptions): Promise<DiscordResponse> {
   // Return deferred response immediately
   const deferredResponse = createDeferredResponse();
@@ -44,11 +47,11 @@ export async function handleAlbumPreferenceSelection({
       if (!dbUser) {
         await editDiscordMessage(applicationId, interactionToken, {
           embeds: [{
-            title: '❌ Error',
-            description: 'Unable to find your account. Please try again.',
+            title: t(locale, 'common.error.title' ),
+            description: t(locale, 'common.error.generic'),
             color: DISCORD_COLORS.RED,
             footer: {
-              text: 'tomomai ともマイ • maimai DX score tracker',
+              text: t(locale, 'common.footer'),
             },
             timestamp: new Date().toISOString(),
           }],
@@ -68,11 +71,13 @@ export async function handleAlbumPreferenceSelection({
       // Show confirmation message
       await editDiscordMessage(applicationId, interactionToken, {
         embeds: [{
-          title: '✅ Preference Set',
-          description: `Your album preference has been set to "${fetchUseAlbums ? 'Save Albums' : 'Don\'t Save Albums'}". Starting fetch...`,
+          title: t(locale, 'fetch.albumPreference.preferenceSet.title'),
+          description: t(locale, 'fetch.albumPreference.preferenceSet.description', {
+            choice: t(locale, fetchUseAlbums ? 'fetch.albumPreference.preferenceSet.save' : 'fetch.albumPreference.preferenceSet.dontSave'),
+          }),
           color: DISCORD_COLORS.GREEN,
           footer: {
-            text: 'tomomai ともマイ • maimai DX score tracker',
+            text: t(locale, 'common.footer'),
           },
           timestamp: new Date().toISOString(),
         }],
@@ -88,16 +93,17 @@ export async function handleAlbumPreferenceSelection({
         regionParam: region,
         applicationId,
         interactionToken,
+        locale,
       });
     } catch (error) {
       getLogger().error({ err: error }, 'Error handling album preference');
       await editDiscordMessage(applicationId, interactionToken, {
         embeds: [{
-          title: '❌ Error',
-          description: 'An error occurred while setting your preference. Please try again.',
+          title: t(locale, 'common.error.title'),
+          description: t(locale, 'common.error.generic'),
           color: DISCORD_COLORS.RED,
           footer: {
-            text: 'tomomai ともマイ • maimai DX score tracker',
+            text: t(locale, 'common.footer'),
           },
           timestamp: new Date().toISOString(),
         }],

--- a/apps/main/src/lib/discord/commands/daily.ts
+++ b/apps/main/src/lib/discord/commands/daily.ts
@@ -3,6 +3,7 @@ import { account, user } from '@/lib/db/schema-pg';
 import { getLogger } from '@/lib/request-logger';
 import { waitUntil } from '@vercel/functions';
 import { and, eq } from 'drizzle-orm';
+import type { Region } from '@/lib/types';
 import {
   createDeferredResponse,
   createErrorResponse,
@@ -12,10 +13,11 @@ import {
 import { resolveRegion } from '../region';
 import { generateAndSendDailyPlaysImage } from '../image-utils';
 import { listDailyPlaysAvailableDays } from '@/server/services/daily-plays-data';
+import { applyStalenessGate } from './staleness';
 
 async function findDbUserByDiscordId(discordUserId: string) {
   const [dbUser] = await db
-    .select({ id: user.id, region: user.region })
+    .select({ id: user.id, name: user.name, username: user.username, region: user.region })
     .from(user)
     .innerJoin(account, eq(account.userId, user.id))
     .where(and(
@@ -32,6 +34,34 @@ export interface DailyCommandOptions {
   day?: string;
   applicationId: string;
   interactionToken: string;
+  forceFetch?: boolean;
+}
+
+export interface ExecuteDailyOptions {
+  dbUserId: string;
+  region: Region;
+  discordUserId: string;
+  day?: string;
+  applicationId: string;
+  interactionToken: string;
+}
+
+export async function executeDailyCommand({
+  dbUserId,
+  region,
+  discordUserId,
+  day,
+  applicationId,
+  interactionToken,
+}: ExecuteDailyOptions): Promise<void> {
+  await generateAndSendDailyPlaysImage({
+    userId: dbUserId,
+    discordUserId,
+    region,
+    day,
+    applicationId,
+    interactionToken,
+  });
 }
 
 export async function handleDailyCommand({
@@ -40,6 +70,7 @@ export async function handleDailyCommand({
   day,
   applicationId,
   interactionToken,
+  forceFetch,
 }: DailyCommandOptions): Promise<DiscordResponse> {
   try {
     if (!discordUserId) {
@@ -53,20 +84,29 @@ export async function handleDailyCommand({
 
     const region = resolveRegion(regionParam, dbUser.region);
 
+    const gate = await applyStalenessGate({
+      command: 'daily',
+      dbUser: { id: dbUser.id, name: dbUser.name, username: dbUser.username, region: dbUser.region },
+      region,
+      discordUserId,
+      forceFetch,
+      payload: day ?? '',
+      day,
+      applicationId,
+      interactionToken,
+    });
+    if (gate) return gate;
+
     const deferredResponse = createDeferredResponse();
 
-    const backgroundTask = (async () => {
-      await generateAndSendDailyPlaysImage({
-        userId: dbUser.id,
-        discordUserId,
-        region,
-        day,
-        applicationId,
-        interactionToken,
-      });
-    })();
-
-    waitUntil(backgroundTask);
+    waitUntil(executeDailyCommand({
+      dbUserId: dbUser.id,
+      region,
+      discordUserId,
+      day,
+      applicationId,
+      interactionToken,
+    }));
 
     return deferredResponse;
   } catch (error) {

--- a/apps/main/src/lib/discord/commands/daily.ts
+++ b/apps/main/src/lib/discord/commands/daily.ts
@@ -14,6 +14,7 @@ import { resolveRegion } from '../region';
 import { generateAndSendDailyPlaysImage } from '../image-utils';
 import { listDailyPlaysAvailableDays } from '@/server/services/daily-plays-data';
 import { applyStalenessGate } from './staleness';
+import { t } from '../i18n';
 
 async function findDbUserByDiscordId(discordUserId: string) {
   const [dbUser] = await db
@@ -35,6 +36,7 @@ export interface DailyCommandOptions {
   applicationId: string;
   interactionToken: string;
   forceFetch?: boolean;
+  locale?: string;
 }
 
 export interface ExecuteDailyOptions {
@@ -44,6 +46,7 @@ export interface ExecuteDailyOptions {
   day?: string;
   applicationId: string;
   interactionToken: string;
+  locale?: string;
 }
 
 export async function executeDailyCommand({
@@ -53,6 +56,7 @@ export async function executeDailyCommand({
   day,
   applicationId,
   interactionToken,
+  locale,
 }: ExecuteDailyOptions): Promise<void> {
   await generateAndSendDailyPlaysImage({
     userId: dbUserId,
@@ -61,6 +65,7 @@ export async function executeDailyCommand({
     day,
     applicationId,
     interactionToken,
+    locale,
   });
 }
 
@@ -71,15 +76,16 @@ export async function handleDailyCommand({
   applicationId,
   interactionToken,
   forceFetch,
+  locale,
 }: DailyCommandOptions): Promise<DiscordResponse> {
   try {
     if (!discordUserId) {
-      return createErrorResponse('Unable to identify Discord user. Please try again.');
+      return createErrorResponse(t(locale, 'common.error.unableToIdentify'), locale);
     }
 
     const dbUser = await findDbUserByDiscordId(discordUserId);
     if (!dbUser) {
-      return createNotRegisteredResponse();
+      return createNotRegisteredResponse(locale);
     }
 
     const region = resolveRegion(regionParam, dbUser.region);
@@ -94,6 +100,7 @@ export async function handleDailyCommand({
       day,
       applicationId,
       interactionToken,
+      locale,
     });
     if (gate) return gate;
 
@@ -106,12 +113,13 @@ export async function handleDailyCommand({
       day,
       applicationId,
       interactionToken,
+      locale,
     }));
 
     return deferredResponse;
   } catch (error) {
     getLogger().error({ err: error }, 'Error handling daily command');
-    return createErrorResponse('An error occurred while fetching your daily plays. Please try again later.');
+    return createErrorResponse(t(locale, 'daily.errorGeneric'), locale);
   }
 }
 
@@ -119,6 +127,7 @@ export interface DailyAutocompleteOptions {
   discordUserId?: string;
   regionParam?: string;
   focusedValue: string;
+  locale?: string;
 }
 
 /**
@@ -130,6 +139,7 @@ export async function handleDailyAutocomplete({
   discordUserId,
   regionParam,
   focusedValue,
+  locale,
 }: DailyAutocompleteOptions): Promise<DiscordResponse> {
   if (!discordUserId) {
     return { type: 8, data: { choices: [] } };
@@ -148,7 +158,7 @@ export async function handleDailyAutocomplete({
       : days;
 
     const choices = filtered.slice(0, 25).map(d => ({
-      name: `${d.day} — ${d.count} ${d.count === 1 ? 'play' : 'plays'}`,
+      name: `${d.day} — ${d.count} ${t(locale, d.count === 1 ? 'daily.play' : 'daily.plays')}`,
       value: d.day,
     }));
 

--- a/apps/main/src/lib/discord/commands/fetch.ts
+++ b/apps/main/src/lib/discord/commands/fetch.ts
@@ -111,61 +111,15 @@ export async function handleFetchCommand({
     // Defer the response since fetch can take a while
     const deferredResponse = createDeferredResponse();
 
-    // Start the fetch process in the background using waitUntil to prevent termination
-    const backgroundTask = (async () => {
-      try {
-        // Start the fetch
-        const startResult = await startFetchServer(dbUser.id, region, undefined, undefined, { skipAfter: true });
-
-        // Send initial message
-        await editDiscordMessage(applicationId, interactionToken, {
-          embeds: [{
-            title: `🔄 Fetching ${regionName} Data`,
-            description: `<@${discordUserId}> Starting data fetch from maimai DX NET...`,
-            color: DISCORD_COLORS.YELLOW,
-            fields: [{
-              name: '📊 Status',
-              value: 'Initializing...',
-              inline: false,
-            }],
-            footer: {
-              text: 'tomomai ともマイ • maimai DX score tracker',
-            },
-            timestamp: new Date().toISOString(),
-          }],
-        });
-
-        // Poll for status updates
-        await pollForUpdates(dbUser.id, dbUser.username ?? dbUser.name, region, regionName, discordUserId, startResult.sessionId, applicationId, interactionToken);
-
-        // Ensure background work (detail fetches for recents/albums) completes
-        await startResult.backgroundWork;
-      } catch (error) {
-        getLogger().error({ err: error }, 'Error in fetch process');
-        const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-
-        // Check if this is an album settings error
-        if (isAlbumSettingsError(errorMessage)) {
-          await editDiscordMessage(applicationId, interactionToken, createAlbumPreferenceMessage(discordUserId, region));
-        } else {
-          // Edit message with error
-          await editDiscordMessage(applicationId, interactionToken, {
-            embeds: [{
-              title: '❌ Fetch Error',
-              description: `<@${discordUserId}> An error occurred while fetching your data: ${errorMessage}`,
-              color: DISCORD_COLORS.RED,
-              footer: {
-                text: 'tomomai ともマイ • maimai DX score tracker',
-              },
-              timestamp: new Date().toISOString(),
-            }],
-          });
-        }
-      }
-    })();
-
-    // Use waitUntil to ensure the background task continues after response
-    waitUntil(backgroundTask);
+    waitUntil(runFetchSession({
+      userId: dbUser.id,
+      username: dbUser.username ?? dbUser.name,
+      region,
+      regionName,
+      discordUserId,
+      applicationId,
+      interactionToken,
+    }));
 
     return deferredResponse;
   } catch (error) {
@@ -174,16 +128,91 @@ export async function handleFetchCommand({
   }
 }
 
+export async function runFetchSession({
+  userId,
+  username,
+  region,
+  regionName,
+  discordUserId,
+  applicationId,
+  interactionToken,
+  onCompleted,
+}: {
+  userId: string;
+  username: string;
+  region: Region;
+  regionName: string;
+  discordUserId: string;
+  applicationId: string;
+  interactionToken: string;
+  onCompleted?: () => Promise<void>;
+}): Promise<boolean> {
+  try {
+    // Start the fetch
+    const startResult = await startFetchServer(userId, region, undefined, undefined, { skipAfter: true });
+
+    // Send initial message
+    await editDiscordMessage(applicationId, interactionToken, {
+      embeds: [{
+        title: `🔄 Fetching ${regionName} Data`,
+        description: `<@${discordUserId}> Starting data fetch from maimai DX NET...`,
+        color: DISCORD_COLORS.YELLOW,
+        fields: [{
+          name: '📊 Status',
+          value: 'Initializing...',
+          inline: false,
+        }],
+        footer: {
+          text: 'tomomai ともマイ • maimai DX score tracker',
+        },
+        timestamp: new Date().toISOString(),
+      }],
+    });
+
+    const completed = await pollForUpdates(userId, region, regionName, discordUserId, startResult.sessionId, applicationId, interactionToken);
+    if (!completed) return false;
+
+    // Ensure background work (detail fetches for recents/albums) completes
+    await startResult.backgroundWork;
+
+    if (onCompleted) {
+      await onCompleted();
+    } else {
+      await handleFetchCompleted(userId, username, region, regionName, discordUserId, applicationId, interactionToken);
+    }
+    return true;
+  } catch (error) {
+    getLogger().error({ err: error }, 'Error in fetch process');
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+
+    if (isAlbumSettingsError(errorMessage)) {
+      await editDiscordMessage(applicationId, interactionToken, createAlbumPreferenceMessage(discordUserId, region));
+    } else {
+      await editDiscordMessage(applicationId, interactionToken, {
+        embeds: [{
+          title: '❌ Fetch Error',
+          description: `<@${discordUserId}> An error occurred while fetching your data: ${errorMessage}`,
+          color: DISCORD_COLORS.RED,
+          footer: {
+            text: 'tomomai ともマイ • maimai DX score tracker',
+          },
+          timestamp: new Date().toISOString(),
+        }],
+      });
+    }
+    return false;
+  }
+}
+
 async function pollForUpdates(
   userId: string,
-  username: string,
   region: Region,
   regionName: string,
   discordUserId: string,
   sessionId: string,
   applicationId: string,
   interactionToken: string
-): Promise<void> {
+): Promise<boolean> {
   const maxAttempts = 600; // 5 minutes max
   let attempts = 0;
 
@@ -193,8 +222,7 @@ async function pollForUpdates(
 
       if (status && status.id === sessionId) {
         if (status.status === "completed") {
-          await handleFetchCompleted(userId, username, region, regionName, discordUserId, applicationId, interactionToken);
-          return;
+          return true;
         } else if (status.status === "failed") {
           const failureReason = status.errorMessage || 'Unknown error';
 
@@ -214,10 +242,10 @@ async function pollForUpdates(
               }],
             });
           }
-          return;
+          return false;
         } else {
           // Still pending, update with progress
-          await updateFetchProgress(status.statusStates || '', region, regionName, discordUserId, applicationId, interactionToken);
+          await updateFetchProgress(status.statusStates || '', regionName, discordUserId, applicationId, interactionToken);
         }
       }
 
@@ -247,6 +275,7 @@ async function pollForUpdates(
       timestamp: new Date().toISOString(),
     }],
   });
+  return false;
 }
 
 async function handleFetchCompleted(
@@ -290,7 +319,6 @@ async function handleFetchCompleted(
 
 async function updateFetchProgress(
   statusStates: string,
-  region: Region,
   regionName: string,
   discordUserId: string,
   applicationId: string,

--- a/apps/main/src/lib/discord/commands/fetch.ts
+++ b/apps/main/src/lib/discord/commands/fetch.ts
@@ -18,6 +18,7 @@ import {
   editDiscordMessage,
   getStateFriendlyName
 } from '../responses';
+import { t } from '../i18n';
 import { Region } from '@/lib/types';
 
 export interface FetchCommandOptions {
@@ -25,25 +26,26 @@ export interface FetchCommandOptions {
   regionParam?: string;
   applicationId: string;
   interactionToken: string;
+  locale?: string;
 }
 
-function createAlbumPreferenceMessage(discordUserId: string, region: Region) {
+function createAlbumPreferenceMessage(discordUserId: string, region: Region, locale?: string) {
   return {
     embeds: [{
-      title: '⚙️ Album Privacy Settings Required',
-      description: `<@${discordUserId}> Before fetching data, you need to set your album privacy preference.`,
+      title: t(locale, 'fetch.albumPreference.title'),
+      description: t(locale, 'fetch.albumPreference.description', { userId: discordUserId }),
       color: DISCORD_COLORS.YELLOW,
       fields: [{
-        name: 'What is this?',
-        value: 'Albums are images stored with your profile data. You can choose whether to save them or not based on your privacy preferences.',
+        name: t(locale, 'fetch.albumPreference.whatName'),
+        value: t(locale, 'fetch.albumPreference.whatValue'),
         inline: false,
       }, {
-        name: 'Privacy Assurance',
-        value: '✓ Albums are stored in your private profile\n✓ Not shared publicly unless you make them public\n✓ Only you can see them\n✓ Automatically deleted after 30 days\n✓ You can change this setting anytime',
+        name: t(locale, 'fetch.albumPreference.privacyName'),
+        value: t(locale, 'fetch.albumPreference.privacyValue'),
         inline: false,
       }],
       footer: {
-        text: 'tomomai ともマイ • maimai DX score tracker',
+        text: t(locale, 'common.footer'),
       },
       timestamp: new Date().toISOString(),
     }],
@@ -53,13 +55,13 @@ function createAlbumPreferenceMessage(discordUserId: string, region: Region) {
         {
           type: 2, // BUTTON
           custom_id: `album_preference_${discordUserId}_${region}_0`,
-          label: 'Don\'t Save Albums',
+          label: t(locale, 'fetch.albumPreference.dontSave'),
           style: 2, // SECONDARY
         },
         {
           type: 2, // BUTTON
           custom_id: `album_preference_${discordUserId}_${region}_1`,
-          label: 'Save Albums',
+          label: t(locale, 'fetch.albumPreference.save'),
           style: 1, // PRIMARY
         },
       ],
@@ -71,11 +73,12 @@ export async function handleFetchCommand({
   discordUserId,
   regionParam,
   applicationId,
-  interactionToken
+  interactionToken,
+  locale,
 }: FetchCommandOptions): Promise<DiscordResponse> {
   try {
     if (!discordUserId) {
-      return createErrorResponse('Unable to identify Discord user. Please try again.');
+      return createErrorResponse(t(locale, 'common.error.unableToIdentify'), locale);
     }
 
     // Find user by Discord ID via account table
@@ -95,17 +98,17 @@ export async function handleFetchCommand({
       .limit(1);
 
     if (!dbUser) {
-      return createNotRegisteredResponse();
+      return createNotRegisteredResponse(locale);
     }
 
     const region = resolveRegion(regionParam, dbUser.region);
-    const regionName = regionDisplayName(region);
+    const regionName = regionDisplayName(region, locale);
 
     // Check current time, if it is within 4AM - 7AM in JST, throw an error
     const now = new Date();
     const jstHour = (now.getUTCHours() + 9) % 24;
     if (jstHour >= 4 && jstHour < 7) {
-      return createErrorResponse("Cannot fetch data during maintenance window (4AM - 7AM JST)");
+      return createErrorResponse(t(locale, 'fetch.maintenanceWindow'), locale);
     }
 
     // Defer the response since fetch can take a while
@@ -119,12 +122,13 @@ export async function handleFetchCommand({
       discordUserId,
       applicationId,
       interactionToken,
+      locale,
     }));
 
     return deferredResponse;
   } catch (error) {
     getLogger().error({ err: error }, 'Error starting fetch');
-    return createErrorResponse('An error occurred while starting the fetch. Please try again later.');
+    return createErrorResponse(t(locale, 'fetch.startError'), locale);
   }
 }
 
@@ -137,6 +141,7 @@ export async function runFetchSession({
   applicationId,
   interactionToken,
   onCompleted,
+  locale,
 }: {
   userId: string;
   username: string;
@@ -146,6 +151,7 @@ export async function runFetchSession({
   applicationId: string;
   interactionToken: string;
   onCompleted?: () => Promise<void>;
+  locale?: string;
 }): Promise<boolean> {
   try {
     // Start the fetch
@@ -154,22 +160,22 @@ export async function runFetchSession({
     // Send initial message
     await editDiscordMessage(applicationId, interactionToken, {
       embeds: [{
-        title: `🔄 Fetching ${regionName} Data`,
-        description: `<@${discordUserId}> Starting data fetch from maimai DX NET...`,
+        title: t(locale, 'fetch.initializing.title', { regionName }),
+        description: t(locale, 'fetch.initializing.description', { userId: discordUserId }),
         color: DISCORD_COLORS.YELLOW,
         fields: [{
-          name: '📊 Status',
-          value: 'Initializing...',
+          name: t(locale, 'fetch.initializing.status'),
+          value: t(locale, 'fetch.initializing.statusValue'),
           inline: false,
         }],
         footer: {
-          text: 'tomomai ともマイ • maimai DX score tracker',
+          text: t(locale, 'common.footer'),
         },
         timestamp: new Date().toISOString(),
       }],
     });
 
-    const completed = await pollForUpdates(userId, region, regionName, discordUserId, startResult.sessionId, applicationId, interactionToken);
+    const completed = await pollForUpdates(userId, region, regionName, discordUserId, startResult.sessionId, applicationId, interactionToken, locale);
     if (!completed) return false;
 
     // Ensure background work (detail fetches for recents/albums) completes
@@ -178,7 +184,7 @@ export async function runFetchSession({
     if (onCompleted) {
       await onCompleted();
     } else {
-      await handleFetchCompleted(userId, username, region, regionName, discordUserId, applicationId, interactionToken);
+      await handleFetchCompleted(userId, username, region, regionName, discordUserId, applicationId, interactionToken, locale);
     }
     return true;
   } catch (error) {
@@ -186,15 +192,15 @@ export async function runFetchSession({
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
 
     if (isAlbumSettingsError(errorMessage)) {
-      await editDiscordMessage(applicationId, interactionToken, createAlbumPreferenceMessage(discordUserId, region));
+      await editDiscordMessage(applicationId, interactionToken, createAlbumPreferenceMessage(discordUserId, region, locale));
     } else {
       await editDiscordMessage(applicationId, interactionToken, {
         embeds: [{
-          title: '❌ Fetch Error',
-          description: `<@${discordUserId}> An error occurred while fetching your data: ${errorMessage}`,
+          title: t(locale, 'fetch.error.title'),
+          description: t(locale, 'fetch.error.description', { userId: discordUserId, message: errorMessage }),
           color: DISCORD_COLORS.RED,
           footer: {
-            text: 'tomomai ともマイ • maimai DX score tracker',
+            text: t(locale, 'common.footer'),
           },
           timestamp: new Date().toISOString(),
         }],
@@ -211,7 +217,8 @@ async function pollForUpdates(
   discordUserId: string,
   sessionId: string,
   applicationId: string,
-  interactionToken: string
+  interactionToken: string,
+  locale?: string,
 ): Promise<boolean> {
   const maxAttempts = 600; // 5 minutes max
   let attempts = 0;
@@ -228,15 +235,15 @@ async function pollForUpdates(
 
           // Check if this is an album settings error
           if (isAlbumSettingsError(failureReason)) {
-            await editDiscordMessage(applicationId, interactionToken, createAlbumPreferenceMessage(discordUserId, region));
+            await editDiscordMessage(applicationId, interactionToken, createAlbumPreferenceMessage(discordUserId, region, locale));
           } else {
             await editDiscordMessage(applicationId, interactionToken, {
               embeds: [{
-                title: '❌ Fetch Failed',
-                description: `<@${discordUserId}> Failed to fetch ${regionName} data: ${failureReason}`,
+                title: t(locale, 'fetch.failed.title'),
+                description: t(locale, 'fetch.failed.description', { userId: discordUserId, regionName }),
                 color: DISCORD_COLORS.RED,
                 footer: {
-                  text: 'tomomai ともマイ • maimai DX score tracker',
+                  text: t(locale, 'common.footer'),
                 },
                 timestamp: new Date().toISOString(),
               }],
@@ -245,7 +252,7 @@ async function pollForUpdates(
           return false;
         } else {
           // Still pending, update with progress
-          await updateFetchProgress(status.statusStates || '', regionName, discordUserId, applicationId, interactionToken);
+          await updateFetchProgress(status.statusStates || '', regionName, discordUserId, applicationId, interactionToken, locale);
         }
       }
 
@@ -261,16 +268,16 @@ async function pollForUpdates(
   // Timeout
   await editDiscordMessage(applicationId, interactionToken, {
     embeds: [{
-      title: '⏰ Fetch Timeout',
-      description: `<@${discordUserId}> The fetch is taking longer than expected. Please check your data on the website.`,
+      title: t(locale, 'fetch.timeout.title'),
+      description: t(locale, 'fetch.timeout.description', { userId: discordUserId }),
       color: DISCORD_COLORS.YELLOW,
       fields: [{
-        name: '🌐 Check Status',
-        value: `[Visit tomomai ともマイ](${resolveBaseUrl()}/) to see your latest data!`,
+        name: t(locale, 'fetch.timeout.statusName'),
+        value: t(locale, 'fetch.timeout.statusValue', { baseUrl: resolveBaseUrl() }),
         inline: false,
       }],
       footer: {
-        text: 'tomomai ともマイ • maimai DX score tracker',
+        text: t(locale, 'common.footer'),
       },
       timestamp: new Date().toISOString(),
     }],
@@ -285,7 +292,8 @@ async function handleFetchCompleted(
   regionName: string,
   discordUserId: string,
   applicationId: string,
-  interactionToken: string
+  interactionToken: string,
+  locale?: string,
 ): Promise<void> {
   // Get the updated snapshot data with new/old chart rating breakdown
   const summary = await getProfileSummary(userId, region);
@@ -301,15 +309,16 @@ async function handleFetchCompleted(
       interactionToken,
       username,
       showGeneratingStatus: true,
+      locale,
     });
   } else {
     await editDiscordMessage(applicationId, interactionToken, {
       embeds: [{
-        title: '✅ Fetch Complete',
-        description: `<@${discordUserId}> Data fetch completed successfully!`,
+        title: t(locale, 'fetch.complete.title'),
+        description: t(locale, 'fetch.complete.description', { userId: discordUserId }),
         color: DISCORD_COLORS.GREEN,
         footer: {
-          text: 'tomomai ともマイ • maimai DX score tracker',
+          text: t(locale, 'common.footer'),
         },
         timestamp: new Date().toISOString(),
       }],
@@ -322,7 +331,8 @@ async function updateFetchProgress(
   regionName: string,
   discordUserId: string,
   applicationId: string,
-  interactionToken: string
+  interactionToken: string,
+  locale?: string,
 ): Promise<void> {
   const allStates = getAllStates();
   const completedStates = parseStatusStates(statusStates);
@@ -345,16 +355,16 @@ async function updateFetchProgress(
 
   await editDiscordMessage(applicationId, interactionToken, {
     embeds: [{
-      title: `🔄 Fetching ${regionName} Data`,
-      description: `<@${discordUserId}> Fetching data from maimai DX NET...`,
+      title: t(locale, 'fetch.progress.title', { regionName }),
+      description: t(locale, 'fetch.progress.description', { userId: discordUserId }),
       color: DISCORD_COLORS.YELLOW,
       fields: [{
-        name: '📊 Status',
+        name: t(locale, 'fetch.progress.status'),
         value: statusText,
         inline: false,
       }],
       footer: {
-        text: 'tomomai ともマイ • maimai DX score tracker',
+        text: t(locale, 'common.footer'),
       },
       timestamp: new Date().toISOString(),
     }],

--- a/apps/main/src/lib/discord/commands/invite.ts
+++ b/apps/main/src/lib/discord/commands/invite.ts
@@ -1,13 +1,16 @@
 import { InteractionResponseType } from 'discord-interactions';
 import { DISCORD_COLORS, DiscordResponse } from '../responses';
 import { resolveBaseUrl } from '../../base-url';
+import { t } from '../i18n';
 
 export interface InviteCommandOptions {
   applicationId: string;
+  locale?: string;
 }
 
 export async function handleInviteCommand({
-  applicationId
+  applicationId,
+  locale,
 }: InviteCommandOptions): Promise<DiscordResponse> {
   const botInviteUrl = `https://discord.com/oauth2/authorize?client_id=${applicationId}&scope=applications.commands`;
 
@@ -16,28 +19,28 @@ export async function handleInviteCommand({
     data: {
       embeds: [
         {
-          title: '🎯 Invite tomomai ともマイ',
-          description: 'Add tomomai ともマイ bot to your Discord server to track and share maimai DX scores!',
+          title: t(locale, 'invite.title'),
+          description: t(locale, 'invite.description'),
           color: DISCORD_COLORS.BLURPLE,
           fields: [
             {
-              name: '✨ Features',
-              value: '• Track scores across International and Japan regions\n• Import data directly from maimai DX NET\n• View historical progress with snapshots\n• Beautiful score analysis and rating calculations',
+              name: t(locale, 'invite.featuresName'),
+              value: t(locale, 'invite.featuresValue'),
               inline: false,
             },
             {
-              name: '🔗 Add to Server',
-              value: `[Click here to invite the bot](${botInviteUrl})`,
+              name: t(locale, 'invite.addName'),
+              value: t(locale, 'invite.addValue', { url: botInviteUrl }),
               inline: false,
             },
             {
-              name: '🌐 Website',
+              name: t(locale, 'invite.websiteName'),
               value: `${resolveBaseUrl()}/`,
               inline: false,
             }
           ],
           footer: {
-            text: 'tomomai ともマイ • maimai DX score tracker',
+            text: t(locale, 'common.footer'),
           },
           timestamp: new Date().toISOString(),
         },

--- a/apps/main/src/lib/discord/commands/profile.ts
+++ b/apps/main/src/lib/discord/commands/profile.ts
@@ -21,6 +21,7 @@ import {
   editDiscordMessage,
 } from '../responses';
 import { applyStalenessGate } from './staleness';
+import { t } from '../i18n';
 
 export interface ProfileCommandOptions {
   discordUserId: string;
@@ -28,6 +29,7 @@ export interface ProfileCommandOptions {
   applicationId: string;
   interactionToken: string;
   forceFetch?: boolean;
+  locale?: string;
 }
 
 export interface ExecuteProfileOptions {
@@ -36,6 +38,7 @@ export interface ExecuteProfileOptions {
   discordUserId: string;
   applicationId: string;
   interactionToken: string;
+  locale?: string;
 }
 
 export async function executeProfileCommand({
@@ -44,22 +47,23 @@ export async function executeProfileCommand({
   discordUserId,
   applicationId,
   interactionToken,
+  locale,
 }: ExecuteProfileOptions): Promise<void> {
-  const regionName = regionDisplayName(region);
+  const regionName = regionDisplayName(region, locale);
 
   // Send initial loading message
   await editDiscordMessage(applicationId, interactionToken, {
     embeds: [{
-      title: `🔄 Loading ${regionName} Profile`,
-      description: `<@${discordUserId}> Generating your profile image...`,
+      title: t(locale, 'profile.loading.title', { regionName }),
+      description: t(locale, 'profile.loading.description', { userId: discordUserId }),
       color: DISCORD_COLORS.BLURPLE,
       fields: [{
-        name: '📊 Status',
-        value: '⏳ Generating Profile Image',
+        name: t(locale, 'profile.loading.status'),
+        value: t(locale, 'profile.loading.statusValue'),
         inline: false,
       }],
       footer: {
-        text: 'tomomai ともマイ • maimai DX score tracker',
+        text: t(locale, 'common.footer'),
       },
       timestamp: new Date().toISOString(),
     }],
@@ -68,7 +72,7 @@ export async function executeProfileCommand({
   const summary = await getProfileSummary(dbUser.id, region);
   if (!summary) {
     await editDiscordMessage(applicationId, interactionToken, {
-      embeds: [createNoDataResponse(regionName).data!.embeds![0]],
+      embeds: [createNoDataResponse(regionName, locale).data!.embeds![0]],
     });
     return;
   }
@@ -82,6 +86,7 @@ export async function executeProfileCommand({
       applicationId,
       interactionToken,
       username: dbUser.username ?? dbUser.name,
+      locale,
     });
   } catch (error) {
     getLogger().error({ err: error }, 'Error generating profile image');
@@ -98,10 +103,11 @@ export async function handleProfileCommand({
   applicationId,
   interactionToken,
   forceFetch,
+  locale,
 }: ProfileCommandOptions): Promise<DiscordResponse> {
   try {
     if (!discordUserId) {
-      return createErrorResponse('Unable to identify Discord user. Please try again.');
+      return createErrorResponse(t(locale, 'common.error.unableToIdentify'), locale);
     }
 
     // Find user by Discord ID via account table
@@ -121,7 +127,7 @@ export async function handleProfileCommand({
       .limit(1);
 
     if (!dbUser) {
-      return createNotRegisteredResponse();
+      return createNotRegisteredResponse(locale);
     }
 
     const region = resolveRegion(regionParam, dbUser.region);
@@ -135,6 +141,7 @@ export async function handleProfileCommand({
       payload: '',
       applicationId,
       interactionToken,
+      locale,
     });
     if (gate) return gate;
 
@@ -147,11 +154,12 @@ export async function handleProfileCommand({
       discordUserId,
       applicationId,
       interactionToken,
+      locale,
     }));
 
     return deferredResponse;
   } catch (error) {
     getLogger().error({ err: error }, 'Error fetching user rating');
-    return createErrorResponse('An error occurred while fetching your rating. Please try again later.');
+    return createErrorResponse(t(locale, 'profile.error'), locale);
   }
 }

--- a/apps/main/src/lib/discord/commands/profile.ts
+++ b/apps/main/src/lib/discord/commands/profile.ts
@@ -6,7 +6,6 @@ import { and, eq } from 'drizzle-orm';
 import type { Region } from '@/lib/types';
 import { generateAndSendProfileImage } from '../image-utils';
 import {
-  formatProfileSummaryContent,
   getProfileSummary,
   regionDisplayName,
   resolveRegion,
@@ -51,33 +50,32 @@ export async function executeProfileCommand({
 }: ExecuteProfileOptions): Promise<void> {
   const regionName = regionDisplayName(region, locale);
 
-  // Send initial loading message
-  await editDiscordMessage(applicationId, interactionToken, {
-    embeds: [{
-      title: t(locale, 'profile.loading.title', { regionName }),
-      description: t(locale, 'profile.loading.description', { userId: discordUserId }),
-      color: DISCORD_COLORS.BLURPLE,
-      fields: [{
-        name: t(locale, 'profile.loading.status'),
-        value: t(locale, 'profile.loading.statusValue'),
-        inline: false,
-      }],
-      footer: {
-        text: t(locale, 'common.footer'),
-      },
-      timestamp: new Date().toISOString(),
-    }],
-  });
-
-  const summary = await getProfileSummary(dbUser.id, region);
-  if (!summary) {
-    await editDiscordMessage(applicationId, interactionToken, {
-      embeds: [createNoDataResponse(regionName, locale).data!.embeds![0]],
-    });
-    return;
-  }
-
   try {
+    await editDiscordMessage(applicationId, interactionToken, {
+      embeds: [{
+        title: t(locale, 'profile.loading.title', { regionName }),
+        description: t(locale, 'profile.loading.description', { userId: discordUserId }),
+        color: DISCORD_COLORS.BLURPLE,
+        fields: [{
+          name: t(locale, 'profile.loading.status'),
+          value: t(locale, 'profile.loading.statusValue'),
+          inline: false,
+        }],
+        footer: {
+          text: t(locale, 'common.footer'),
+        },
+        timestamp: new Date().toISOString(),
+      }],
+    });
+
+    const summary = await getProfileSummary(dbUser.id, region);
+    if (!summary) {
+      await editDiscordMessage(applicationId, interactionToken, {
+        embeds: [createNoDataResponse(regionName, locale).data!.embeds![0]],
+      });
+      return;
+    }
+
     await new Promise(resolve => setTimeout(resolve, 500));
     await generateAndSendProfileImage({
       summary,
@@ -91,7 +89,7 @@ export async function executeProfileCommand({
   } catch (error) {
     getLogger().error({ err: error }, 'Error generating profile image');
     await editDiscordMessage(applicationId, interactionToken, {
-      content: formatProfileSummaryContent(discordUserId, summary, regionName),
+      content: t(locale, 'profile.error'),
       embeds: [],
     });
   }

--- a/apps/main/src/lib/discord/commands/profile.ts
+++ b/apps/main/src/lib/discord/commands/profile.ts
@@ -3,6 +3,7 @@ import { account, user } from '@/lib/db/schema-pg';
 import { getLogger } from '@/lib/request-logger';
 import { waitUntil } from '@vercel/functions';
 import { and, eq } from 'drizzle-orm';
+import type { Region } from '@/lib/types';
 import { generateAndSendProfileImage } from '../image-utils';
 import {
   formatProfileSummaryContent,
@@ -19,19 +20,84 @@ import {
   DiscordResponse,
   editDiscordMessage,
 } from '../responses';
+import { applyStalenessGate } from './staleness';
 
 export interface ProfileCommandOptions {
   discordUserId: string;
   regionParam?: string;
   applicationId: string;
   interactionToken: string;
+  forceFetch?: boolean;
+}
+
+export interface ExecuteProfileOptions {
+  dbUser: { id: string; name: string; username: string | null; region: Region | null };
+  region: Region;
+  discordUserId: string;
+  applicationId: string;
+  interactionToken: string;
+}
+
+export async function executeProfileCommand({
+  dbUser,
+  region,
+  discordUserId,
+  applicationId,
+  interactionToken,
+}: ExecuteProfileOptions): Promise<void> {
+  const regionName = regionDisplayName(region);
+
+  // Send initial loading message
+  await editDiscordMessage(applicationId, interactionToken, {
+    embeds: [{
+      title: `🔄 Loading ${regionName} Profile`,
+      description: `<@${discordUserId}> Generating your profile image...`,
+      color: DISCORD_COLORS.BLURPLE,
+      fields: [{
+        name: '📊 Status',
+        value: '⏳ Generating Profile Image',
+        inline: false,
+      }],
+      footer: {
+        text: 'tomomai ともマイ • maimai DX score tracker',
+      },
+      timestamp: new Date().toISOString(),
+    }],
+  });
+
+  const summary = await getProfileSummary(dbUser.id, region);
+  if (!summary) {
+    await editDiscordMessage(applicationId, interactionToken, {
+      embeds: [createNoDataResponse(regionName).data!.embeds![0]],
+    });
+    return;
+  }
+
+  try {
+    await new Promise(resolve => setTimeout(resolve, 500));
+    await generateAndSendProfileImage({
+      summary,
+      discordUserId,
+      regionName,
+      applicationId,
+      interactionToken,
+      username: dbUser.username ?? dbUser.name,
+    });
+  } catch (error) {
+    getLogger().error({ err: error }, 'Error generating profile image');
+    await editDiscordMessage(applicationId, interactionToken, {
+      content: formatProfileSummaryContent(discordUserId, summary, regionName),
+      embeds: [],
+    });
+  }
 }
 
 export async function handleProfileCommand({
   discordUserId,
   regionParam,
   applicationId,
-  interactionToken
+  interactionToken,
+  forceFetch,
 }: ProfileCommandOptions): Promise<DiscordResponse> {
   try {
     if (!discordUserId) {
@@ -59,62 +125,29 @@ export async function handleProfileCommand({
     }
 
     const region = resolveRegion(regionParam, dbUser.region);
-    const regionName = regionDisplayName(region);
+
+    const gate = await applyStalenessGate({
+      command: 'profile',
+      dbUser: { id: dbUser.id, name: dbUser.name, username: dbUser.username, region: dbUser.region },
+      region,
+      discordUserId,
+      forceFetch,
+      payload: '',
+      applicationId,
+      interactionToken,
+    });
+    if (gate) return gate;
 
     // Defer the response since image generation can take a moment
     const deferredResponse = createDeferredResponse();
 
-    // Generate and send profile in the background
-    const backgroundTask = (async () => {
-      // Send initial loading message
-      await editDiscordMessage(applicationId, interactionToken, {
-        embeds: [{
-          title: `🔄 Loading ${regionName} Profile`,
-          description: `<@${discordUserId}> Generating your profile image...`,
-          color: DISCORD_COLORS.BLURPLE,
-          fields: [{
-            name: '📊 Status',
-            value: '⏳ Generating Profile Image',
-            inline: false,
-          }],
-          footer: {
-            text: 'tomomai ともマイ • maimai DX score tracker',
-          },
-          timestamp: new Date().toISOString(),
-        }],
-      });
-
-      const summary = await getProfileSummary(dbUser.id, region);
-      if (!summary) {
-        await editDiscordMessage(applicationId, interactionToken, {
-          embeds: [createNoDataResponse(regionName).data!.embeds![0]],
-        });
-        return;
-      }
-
-      try {
-        // Generate and send the profile image with the simple roast text
-        await new Promise(resolve => setTimeout(resolve, 500));
-        await generateAndSendProfileImage({
-          summary,
-          discordUserId,
-          regionName,
-          applicationId,
-          interactionToken,
-          username: dbUser.username ?? dbUser.name,
-        });
-      } catch (error) {
-        getLogger().error({ err: error }, 'Error generating profile image');
-        // Fallback to text-only roast
-        await editDiscordMessage(applicationId, interactionToken, {
-          content: formatProfileSummaryContent(discordUserId, summary, regionName),
-          embeds: [],
-        });
-      }
-    })();
-
-    // Use waitUntil to ensure the background task continues after response
-    waitUntil(backgroundTask);
+    waitUntil(executeProfileCommand({
+      dbUser,
+      region,
+      discordUserId,
+      applicationId,
+      interactionToken,
+    }));
 
     return deferredResponse;
   } catch (error) {

--- a/apps/main/src/lib/discord/commands/recents.ts
+++ b/apps/main/src/lib/discord/commands/recents.ts
@@ -3,6 +3,7 @@ import { account, user } from '@/lib/db/schema-pg';
 import { getLogger } from '@/lib/request-logger';
 import { waitUntil } from '@vercel/functions';
 import { and, eq } from 'drizzle-orm';
+import type { Region } from '@/lib/types';
 import {
   createDeferredResponse,
   createErrorResponse,
@@ -11,6 +12,7 @@ import {
 } from '../responses';
 import { resolveRegion } from '../region';
 import { generateAndSendCreditImage } from '../image-utils';
+import { applyStalenessGate } from './staleness';
 
 export interface RecentsCommandOptions {
   discordUserId: string;
@@ -18,6 +20,34 @@ export interface RecentsCommandOptions {
   applicationId: string;
   interactionToken: string;
   skip?: number;
+  forceFetch?: boolean;
+}
+
+export interface ExecuteRecentsOptions {
+  dbUserId: string;
+  region: Region;
+  discordUserId: string;
+  applicationId: string;
+  interactionToken: string;
+  skip?: number;
+}
+
+export async function executeRecentsCommand({
+  dbUserId,
+  region,
+  discordUserId,
+  applicationId,
+  interactionToken,
+  skip = 0,
+}: ExecuteRecentsOptions): Promise<void> {
+  await generateAndSendCreditImage({
+    userId: dbUserId,
+    discordUserId,
+    region,
+    applicationId,
+    interactionToken,
+    skip,
+  });
 }
 
 export async function handleRecentsCommand({
@@ -26,6 +56,7 @@ export async function handleRecentsCommand({
   applicationId,
   interactionToken,
   skip = 0,
+  forceFetch,
 }: RecentsCommandOptions): Promise<DiscordResponse> {
   try {
     if (!discordUserId) {
@@ -54,23 +85,32 @@ export async function handleRecentsCommand({
 
     const region = resolveRegion(regionParam, dbUser.region);
 
+    // Staleness/force-fetch only apply on the initial invocation, not pagination.
+    if (!skip) {
+      const gate = await applyStalenessGate({
+        command: 'recents',
+        dbUser: { id: dbUser.id, name: dbUser.name, username: dbUser.username, region: dbUser.region },
+        region,
+        discordUserId,
+        forceFetch,
+        payload: '',
+        applicationId,
+        interactionToken,
+      });
+      if (gate) return gate;
+    }
+
     // Defer the response since image generation can take a moment
     const deferredResponse = createDeferredResponse();
 
-    // Generate and send credit image in the background
-    const backgroundTask = (async () => {
-      await generateAndSendCreditImage({
-        userId: dbUser.id,
-        discordUserId,
-        region,
-        applicationId,
-        interactionToken,
-        skip,
-      });
-    })();
-
-    // Use waitUntil to ensure the background task continues
-    waitUntil(backgroundTask);
+    waitUntil(executeRecentsCommand({
+      dbUserId: dbUser.id,
+      region,
+      discordUserId,
+      applicationId,
+      interactionToken,
+      skip,
+    }));
 
     return deferredResponse;
 

--- a/apps/main/src/lib/discord/commands/recents.ts
+++ b/apps/main/src/lib/discord/commands/recents.ts
@@ -13,6 +13,7 @@ import {
 import { resolveRegion } from '../region';
 import { generateAndSendCreditImage } from '../image-utils';
 import { applyStalenessGate } from './staleness';
+import { t } from '../i18n';
 
 export interface RecentsCommandOptions {
   discordUserId: string;
@@ -21,6 +22,7 @@ export interface RecentsCommandOptions {
   interactionToken: string;
   skip?: number;
   forceFetch?: boolean;
+  locale?: string;
 }
 
 export interface ExecuteRecentsOptions {
@@ -30,6 +32,7 @@ export interface ExecuteRecentsOptions {
   applicationId: string;
   interactionToken: string;
   skip?: number;
+  locale?: string;
 }
 
 export async function executeRecentsCommand({
@@ -39,6 +42,7 @@ export async function executeRecentsCommand({
   applicationId,
   interactionToken,
   skip = 0,
+  locale,
 }: ExecuteRecentsOptions): Promise<void> {
   await generateAndSendCreditImage({
     userId: dbUserId,
@@ -47,6 +51,7 @@ export async function executeRecentsCommand({
     applicationId,
     interactionToken,
     skip,
+    locale,
   });
 }
 
@@ -57,10 +62,11 @@ export async function handleRecentsCommand({
   interactionToken,
   skip = 0,
   forceFetch,
+  locale,
 }: RecentsCommandOptions): Promise<DiscordResponse> {
   try {
     if (!discordUserId) {
-      return createErrorResponse('Unable to identify Discord user. Please try again.');
+      return createErrorResponse(t(locale, 'common.error.unableToIdentify'), locale);
     }
 
     // Find user by Discord ID via account table
@@ -80,7 +86,7 @@ export async function handleRecentsCommand({
       .limit(1);
 
     if (!dbUser) {
-      return createNotRegisteredResponse();
+      return createNotRegisteredResponse(locale);
     }
 
     const region = resolveRegion(regionParam, dbUser.region);
@@ -96,6 +102,7 @@ export async function handleRecentsCommand({
         payload: '',
         applicationId,
         interactionToken,
+        locale,
       });
       if (gate) return gate;
     }
@@ -110,12 +117,13 @@ export async function handleRecentsCommand({
       applicationId,
       interactionToken,
       skip,
+      locale,
     }));
 
     return deferredResponse;
 
   } catch (error) {
     getLogger().error({ err: error }, 'Error handling recents command');
-    return createErrorResponse('An error occurred while fetching your recent plays. Please try again later.');
+    return createErrorResponse(t(locale, 'recents.errorGeneric'), locale);
   }
 }

--- a/apps/main/src/lib/discord/commands/recommend.ts
+++ b/apps/main/src/lib/discord/commands/recommend.ts
@@ -19,6 +19,7 @@ import {
 } from '../responses';
 import { regionDisplayName, resolveRegion } from '../region';
 import { applyStalenessGate } from './staleness';
+import { t } from '../i18n';
 
 export interface RecommendCommandOptions {
   discordUserId: string;
@@ -26,6 +27,7 @@ export interface RecommendCommandOptions {
   applicationId: string;
   interactionToken: string;
   forceFetch?: boolean;
+  locale?: string;
 }
 
 export interface ExecuteRecommendOptions {
@@ -34,6 +36,7 @@ export interface ExecuteRecommendOptions {
   discordUserId: string;
   applicationId: string;
   interactionToken: string;
+  locale?: string;
 }
 
 export async function executeRecommendCommand({
@@ -42,13 +45,14 @@ export async function executeRecommendCommand({
   discordUserId,
   applicationId,
   interactionToken,
+  locale,
 }: ExecuteRecommendOptions): Promise<void> {
-  const regionName = regionDisplayName(region);
+  const regionName = regionDisplayName(region, locale);
   try {
     const data = await fetchLatestSnapshotData(dbUserId, region);
     if (!data) {
       await editDiscordMessage(applicationId, interactionToken, {
-        embeds: [createNoDataResponse(regionName).data!.embeds![0]],
+        embeds: [createNoDataResponse(regionName, locale).data!.embeds![0]],
       });
       return;
     }
@@ -62,8 +66,8 @@ export async function executeRecommendCommand({
     );
 
     const embed = deduped.length === 0
-      ? buildNoRecommendationsEmbed(regionName, discordUserId)
-      : buildRecommendationEmbed(deduped, regionName, discordUserId);
+      ? buildNoRecommendationsEmbed(regionName, discordUserId, locale)
+      : buildRecommendationEmbed(deduped, regionName, discordUserId, locale);
 
     await editDiscordMessage(applicationId, interactionToken, {
       embeds: [embed],
@@ -71,7 +75,7 @@ export async function executeRecommendCommand({
   } catch (error) {
     getLogger().error({ err: error }, 'Error generating recommendations');
     await editDiscordMessage(applicationId, interactionToken, {
-      content: 'An error occurred while generating recommendations. Please try again later.',
+      content: t(locale, 'recommend.errorContent'),
     });
   }
 }
@@ -113,28 +117,28 @@ function formatRow(rec: RecommendationData, rank: number): string {
   ].join('\n');
 }
 
-function buildRecommendationEmbed(recommendations: RecommendationData[], regionName: string, discordUserId: string) {
+function buildRecommendationEmbed(recommendations: RecommendationData[], regionName: string, discordUserId: string, locale?: string) {
   const top = recommendations.slice(0, MAX_ROWS);
   const body = top.map((r, i) => formatRow(r, i + 1)).join('\n');
 
   return {
-    title: `🎯 ${regionName} Recommendations`,
-    description: `<@${discordUserId}>\n\`\`\`\n${body}\n\`\`\``,
+    title: t(locale, 'recommend.title', { regionName }),
+    description: t(locale, 'recommend.description', { userId: discordUserId, body }),
     color: DISCORD_COLORS.BLURPLE,
     footer: {
-      text: 'tomomai ともマイ • maimai DX score tracker',
+      text: t(locale, 'common.footer'),
     },
     timestamp: new Date().toISOString(),
   };
 }
 
-function buildNoRecommendationsEmbed(regionName: string, discordUserId: string) {
+function buildNoRecommendationsEmbed(regionName: string, discordUserId: string, locale?: string) {
   return {
-    title: `🎯 ${regionName} Recommendations`,
-    description: `<@${discordUserId}> No recommendations — your scores are already optimal!`,
+    title: t(locale, 'recommend.none.title', { regionName }),
+    description: t(locale, 'recommend.none.description', { userId: discordUserId }),
     color: DISCORD_COLORS.GREEN,
     footer: {
-      text: 'tomomai ともマイ • maimai DX score tracker',
+      text: t(locale, 'common.footer'),
     },
     timestamp: new Date().toISOString(),
   };
@@ -146,10 +150,11 @@ export async function handleRecommendCommand({
   applicationId,
   interactionToken,
   forceFetch,
+  locale,
 }: RecommendCommandOptions): Promise<DiscordResponse> {
   try {
     if (!discordUserId) {
-      return createErrorResponse('Unable to identify Discord user. Please try again.');
+      return createErrorResponse(t(locale, 'common.error.unableToIdentify'), locale);
     }
 
     const [dbUser] = await db
@@ -168,7 +173,7 @@ export async function handleRecommendCommand({
       .limit(1);
 
     if (!dbUser) {
-      return createNotRegisteredResponse();
+      return createNotRegisteredResponse(locale);
     }
 
     const region = resolveRegion(regionParam, dbUser.region);
@@ -182,6 +187,7 @@ export async function handleRecommendCommand({
       payload: '',
       applicationId,
       interactionToken,
+      locale,
     });
     if (gate) return gate;
 
@@ -193,11 +199,12 @@ export async function handleRecommendCommand({
       discordUserId,
       applicationId,
       interactionToken,
+      locale,
     }));
 
     return deferredResponse;
   } catch (error) {
     getLogger().error({ err: error }, 'Error handling recommend command');
-    return createErrorResponse('An error occurred while generating recommendations. Please try again later.');
+    return createErrorResponse(t(locale, 'recommend.errorGeneric'), locale);
   }
 }

--- a/apps/main/src/lib/discord/commands/recommend.ts
+++ b/apps/main/src/lib/discord/commands/recommend.ts
@@ -2,7 +2,7 @@ import { db } from '@/lib/db';
 import { account, user } from '@/lib/db/schema-pg';
 import { renderLevelPrecise } from '@/lib/name-utils';
 import { addRatingsAndSort, SongWithRating } from '@/lib/rating-calculator';
-import { SongWithScore } from '@/lib/types';
+import { SongWithScore, Region } from '@/lib/types';
 import { fetchLatestSnapshotData } from '@/server/queries/snapshots';
 import { generateRecommendations, RecommendationData } from '@/server/queries/recommendations';
 import { getLogger } from '@/lib/request-logger';
@@ -18,12 +18,62 @@ import {
   editDiscordMessage,
 } from '../responses';
 import { regionDisplayName, resolveRegion } from '../region';
+import { applyStalenessGate } from './staleness';
 
 export interface RecommendCommandOptions {
   discordUserId: string;
   regionParam?: string;
   applicationId: string;
   interactionToken: string;
+  forceFetch?: boolean;
+}
+
+export interface ExecuteRecommendOptions {
+  dbUserId: string;
+  region: Region;
+  discordUserId: string;
+  applicationId: string;
+  interactionToken: string;
+}
+
+export async function executeRecommendCommand({
+  dbUserId,
+  region,
+  discordUserId,
+  applicationId,
+  interactionToken,
+}: ExecuteRecommendOptions): Promise<void> {
+  const regionName = regionDisplayName(region);
+  try {
+    const data = await fetchLatestSnapshotData(dbUserId, region);
+    if (!data) {
+      await editDiscordMessage(applicationId, interactionToken, {
+        embeds: [createNoDataResponse(regionName).data!.embeds![0]],
+      });
+      return;
+    }
+
+    const { snapshot, songs } = data;
+    const songsWithRating = addRatingsAndSort(songs as SongWithScore[], snapshot.gameVersion) as SongWithRating[];
+    const recommendations = generateRecommendations(songsWithRating, snapshot.gameVersion);
+
+    const deduped = recommendations.filter((rec, index, self) =>
+      index === self.findIndex(r => r.song.songId === rec.song.songId && r.song.difficulty === rec.song.difficulty)
+    );
+
+    const embed = deduped.length === 0
+      ? buildNoRecommendationsEmbed(regionName, discordUserId)
+      : buildRecommendationEmbed(deduped, regionName, discordUserId);
+
+    await editDiscordMessage(applicationId, interactionToken, {
+      embeds: [embed],
+    });
+  } catch (error) {
+    getLogger().error({ err: error }, 'Error generating recommendations');
+    await editDiscordMessage(applicationId, interactionToken, {
+      content: 'An error occurred while generating recommendations. Please try again later.',
+    });
+  }
 }
 
 const MAX_ROWS = 10;
@@ -95,6 +145,7 @@ export async function handleRecommendCommand({
   regionParam,
   applicationId,
   interactionToken,
+  forceFetch,
 }: RecommendCommandOptions): Promise<DiscordResponse> {
   try {
     if (!discordUserId) {
@@ -104,6 +155,8 @@ export async function handleRecommendCommand({
     const [dbUser] = await db
       .select({
         id: user.id,
+        name: user.name,
+        username: user.username,
         region: user.region,
       })
       .from(user)
@@ -119,44 +172,28 @@ export async function handleRecommendCommand({
     }
 
     const region = resolveRegion(regionParam, dbUser.region);
-    const regionName = regionDisplayName(region);
+
+    const gate = await applyStalenessGate({
+      command: 'recommend',
+      dbUser: { id: dbUser.id, name: dbUser.name, username: dbUser.username, region: dbUser.region },
+      region,
+      discordUserId,
+      forceFetch,
+      payload: '',
+      applicationId,
+      interactionToken,
+    });
+    if (gate) return gate;
 
     const deferredResponse = createDeferredResponse();
 
-    const backgroundTask = (async () => {
-      try {
-        const data = await fetchLatestSnapshotData(dbUser.id, region);
-        if (!data) {
-          await editDiscordMessage(applicationId, interactionToken, {
-            embeds: [createNoDataResponse(regionName).data!.embeds![0]],
-          });
-          return;
-        }
-
-        const { snapshot, songs } = data;
-        const songsWithRating = addRatingsAndSort(songs as SongWithScore[], snapshot.gameVersion) as SongWithRating[];
-        const recommendations = generateRecommendations(songsWithRating, snapshot.gameVersion);
-
-        const deduped = recommendations.filter((rec, index, self) =>
-          index === self.findIndex(r => r.song.songId === rec.song.songId && r.song.difficulty === rec.song.difficulty)
-        );
-
-        const embed = deduped.length === 0
-          ? buildNoRecommendationsEmbed(regionName, discordUserId)
-          : buildRecommendationEmbed(deduped, regionName, discordUserId);
-
-        await editDiscordMessage(applicationId, interactionToken, {
-          embeds: [embed],
-        });
-      } catch (error) {
-        getLogger().error({ err: error }, 'Error generating recommendations');
-        await editDiscordMessage(applicationId, interactionToken, {
-          content: 'An error occurred while generating recommendations. Please try again later.',
-        });
-      }
-    })();
-
-    waitUntil(backgroundTask);
+    waitUntil(executeRecommendCommand({
+      dbUserId: dbUser.id,
+      region,
+      discordUserId,
+      applicationId,
+      interactionToken,
+    }));
 
     return deferredResponse;
   } catch (error) {

--- a/apps/main/src/lib/discord/commands/staleness.ts
+++ b/apps/main/src/lib/discord/commands/staleness.ts
@@ -11,7 +11,8 @@ import {
   DISCORD_COLORS,
   editDiscordMessage,
 } from '../responses';
-import { regionDisplayName, resolveRegion } from '../region';
+import { resolveRegion } from '../region';
+import { t } from '../i18n';
 import { runFetchSession } from './fetch';
 import { executeProfileCommand } from './profile';
 import { executeRecentsCommand } from './recents';
@@ -48,20 +49,21 @@ async function runCommand(
   discordUserId: string,
   applicationId: string,
   interactionToken: string,
+  locale: string | undefined,
   day?: string,
 ): Promise<void> {
   switch (command) {
     case 'profile':
-      await executeProfileCommand({ dbUser, region, discordUserId, applicationId, interactionToken });
+      await executeProfileCommand({ dbUser, region, discordUserId, applicationId, interactionToken, locale });
       break;
     case 'recents':
-      await executeRecentsCommand({ dbUserId: dbUser.id, region, discordUserId, applicationId, interactionToken });
+      await executeRecentsCommand({ dbUserId: dbUser.id, region, discordUserId, applicationId, interactionToken, locale });
       break;
     case 'recommend':
-      await executeRecommendCommand({ dbUserId: dbUser.id, region, discordUserId, applicationId, interactionToken });
+      await executeRecommendCommand({ dbUserId: dbUser.id, region, discordUserId, applicationId, interactionToken, locale });
       break;
     case 'daily':
-      await executeDailyCommand({ dbUserId: dbUser.id, region, discordUserId, day, applicationId, interactionToken });
+      await executeDailyCommand({ dbUserId: dbUser.id, region, discordUserId, day, applicationId, interactionToken, locale });
       break;
   }
 }
@@ -76,6 +78,7 @@ export interface ApplyStalenessGateOptions {
   day?: string;
   applicationId: string;
   interactionToken: string;
+  locale?: string;
 }
 
 /**
@@ -93,9 +96,8 @@ export async function applyStalenessGate({
   day,
   applicationId,
   interactionToken,
+  locale,
 }: ApplyStalenessGateOptions): Promise<DiscordResponse | null> {
-  const regionName = regionDisplayName(region);
-
   if (forceFetch) {
     return runRefetchThenCommand({
       command,
@@ -104,6 +106,7 @@ export async function applyStalenessGate({
       discordUserId,
       applicationId,
       interactionToken,
+      locale,
       day,
     });
   }
@@ -111,13 +114,15 @@ export async function applyStalenessGate({
   try {
     const lastFetchedAt = await getLatestSnapshotFetchedAt(dbUser.id, region);
     if (lastFetchedAt && isStale(lastFetchedAt)) {
+      const { regionDisplayName } = await import('../region');
       return getStalePromptResponse({
         command,
         discordUserId,
         region,
-        regionName,
+        regionName: regionDisplayName(region, locale),
         lastFetchedAt,
         payload,
+        locale,
       });
     }
   } catch (error) {
@@ -134,6 +139,7 @@ export interface RunRefetchThenCommandOptions {
   discordUserId: string;
   applicationId: string;
   interactionToken: string;
+  locale?: string;
   day?: string;
 }
 
@@ -149,19 +155,21 @@ export function runRefetchThenCommand({
   discordUserId,
   applicationId,
   interactionToken,
+  locale,
   day,
 }: RunRefetchThenCommandOptions): DiscordResponse {
   const deferredResponse = createDeferredResponse();
 
   const backgroundTask = (async () => {
-    const regionName = regionDisplayName(region);
+    const { regionDisplayName } = await import('../region');
+    const regionName = regionDisplayName(region, locale);
     try {
       await editDiscordMessage(applicationId, interactionToken, {
         embeds: [{
-          title: `🔄 Refetching ${regionName} Data`,
-          description: `<@${discordUserId}> Refetching from maimai DX NET, then continuing...`,
+          title: t(locale, 'staleness.refetching.title', { regionName }),
+          description: t(locale, 'staleness.refetching.description', { userId: discordUserId }),
           color: DISCORD_COLORS.YELLOW,
-          footer: { text: 'tomomai ともマイ • maimai DX score tracker' },
+          footer: { text: t(locale, 'common.footer') },
           timestamp: new Date().toISOString(),
         }],
         components: [],
@@ -175,20 +183,21 @@ export function runRefetchThenCommand({
         discordUserId,
         applicationId,
         interactionToken,
+        locale,
         onCompleted: async () => { /* command runs next */ },
       });
 
       if (!ok) return; // runFetchSession already posted the error/timeout embed
 
-      await runCommand(command, dbUser, region, discordUserId, applicationId, interactionToken, day);
+      await runCommand(command, dbUser, region, discordUserId, applicationId, interactionToken, locale, day);
     } catch (error) {
       getLogger().error({ err: error }, 'Error in refetch-then-command');
       await editDiscordMessage(applicationId, interactionToken, {
         embeds: [{
-          title: '❌ Error',
-          description: `<@${discordUserId}> An error occurred while refetching. Please try again later.`,
+          title: t(locale, 'staleness.refetchError.title'),
+          description: t(locale, 'staleness.refetchError.description', { userId: discordUserId }),
           color: DISCORD_COLORS.RED,
-          footer: { text: 'tomomai ともマイ • maimai DX score tracker' },
+          footer: { text: t(locale, 'common.footer') },
           timestamp: new Date().toISOString(),
         }],
       });
@@ -208,6 +217,7 @@ export interface HandleStalenessChoiceOptions {
   payload: string;
   applicationId: string;
   interactionToken: string;
+  locale?: string;
 }
 
 /**
@@ -222,14 +232,15 @@ export async function handleStalenessChoice({
   payload,
   applicationId,
   interactionToken,
+  locale,
 }: HandleStalenessChoiceOptions): Promise<DiscordResponse> {
   if (!discordUserId) {
-    return createErrorResponse('Unable to identify Discord user.');
+    return createErrorResponse(t(locale, 'common.error.unableToIdentifyShort'), locale);
   }
 
   const dbUser = await resolveDbUser(discordUserId);
   if (!dbUser) {
-    return createErrorResponse('Unable to find your account. Please try again.');
+    return createErrorResponse(t(locale, 'common.error.generic'), locale);
   }
 
   const resolvedRegion = resolveRegion(region, dbUser.region);
@@ -243,6 +254,7 @@ export async function handleStalenessChoice({
       discordUserId,
       applicationId,
       interactionToken,
+      locale,
       day,
     });
   }
@@ -253,23 +265,23 @@ export async function handleStalenessChoice({
     try {
       await editDiscordMessage(applicationId, interactionToken, {
         embeds: [{
-          title: '⏳ Loading...',
-          description: `<@${discordUserId}> Continuing with your current data...`,
+          title: t(locale, 'common.loading.title'),
+          description: t(locale, 'common.loading.description', { userId: discordUserId }),
           color: DISCORD_COLORS.BLURPLE,
-          footer: { text: 'tomomai ともマイ • maimai DX score tracker' },
+          footer: { text: t(locale, 'common.footer') },
           timestamp: new Date().toISOString(),
         }],
         components: [],
       });
-      await runCommand(command, dbUser, resolvedRegion, discordUserId, applicationId, interactionToken, day);
+      await runCommand(command, dbUser, resolvedRegion, discordUserId, applicationId, interactionToken, locale, day);
     } catch (error) {
       getLogger().error({ err: error }, 'Error in staleness continue path');
       await editDiscordMessage(applicationId, interactionToken, {
         embeds: [{
-          title: '❌ Error',
-          description: `<@${discordUserId}> An error occurred. Please try again later.`,
+          title: t(locale, 'common.error.title'),
+          description: t(locale, 'common.error.generic'),
           color: DISCORD_COLORS.RED,
-          footer: { text: 'tomomai ともマイ • maimai DX score tracker' },
+          footer: { text: t(locale, 'common.footer') },
           timestamp: new Date().toISOString(),
         }],
       });

--- a/apps/main/src/lib/discord/commands/staleness.ts
+++ b/apps/main/src/lib/discord/commands/staleness.ts
@@ -1,0 +1,282 @@
+import { db } from '@/lib/db';
+import { account, user } from '@/lib/db/schema-pg';
+import { getLogger } from '@/lib/request-logger';
+import { waitUntil } from '@vercel/functions';
+import { and, eq } from 'drizzle-orm';
+import type { Region } from '@/lib/types';
+import {
+  createDeferredResponse,
+  createErrorResponse,
+  DiscordResponse,
+  DISCORD_COLORS,
+  editDiscordMessage,
+} from '../responses';
+import { regionDisplayName, resolveRegion } from '../region';
+import { runFetchSession } from './fetch';
+import { executeProfileCommand } from './profile';
+import { executeRecentsCommand } from './recents';
+import { executeRecommendCommand } from './recommend';
+import { executeDailyCommand } from './daily';
+import {
+  getStalePromptResponse,
+  isStale,
+  type StaleCommand,
+} from '../staleness';
+import { getLatestSnapshotFetchedAt } from '@/server/queries/snapshots';
+
+interface ResolvedUser {
+  id: string;
+  name: string;
+  username: string | null;
+  region: Region | null;
+}
+
+async function resolveDbUser(discordUserId: string): Promise<ResolvedUser | null> {
+  const [dbUser] = await db
+    .select({ id: user.id, name: user.name, username: user.username, region: user.region })
+    .from(user)
+    .innerJoin(account, eq(account.userId, user.id))
+    .where(and(eq(account.accountId, discordUserId), eq(account.providerId, 'discord')))
+    .limit(1);
+  return dbUser ?? null;
+}
+
+async function runCommand(
+  command: StaleCommand,
+  dbUser: ResolvedUser,
+  region: Region,
+  discordUserId: string,
+  applicationId: string,
+  interactionToken: string,
+  day?: string,
+): Promise<void> {
+  switch (command) {
+    case 'profile':
+      await executeProfileCommand({ dbUser, region, discordUserId, applicationId, interactionToken });
+      break;
+    case 'recents':
+      await executeRecentsCommand({ dbUserId: dbUser.id, region, discordUserId, applicationId, interactionToken });
+      break;
+    case 'recommend':
+      await executeRecommendCommand({ dbUserId: dbUser.id, region, discordUserId, applicationId, interactionToken });
+      break;
+    case 'daily':
+      await executeDailyCommand({ dbUserId: dbUser.id, region, discordUserId, day, applicationId, interactionToken });
+      break;
+  }
+}
+
+export interface ApplyStalenessGateOptions {
+  command: StaleCommand;
+  dbUser: ResolvedUser;
+  region: Region;
+  discordUserId: string;
+  forceFetch?: boolean;
+  payload: string;
+  day?: string;
+  applicationId: string;
+  interactionToken: string;
+}
+
+/**
+ * Decide whether a data command should short-circuit before running.
+ * Returns a `DiscordResponse` (force-refetch or staleness prompt) when it
+ * should, or `null` when the command should proceed normally.
+ */
+export async function applyStalenessGate({
+  command,
+  dbUser,
+  region,
+  discordUserId,
+  forceFetch,
+  payload,
+  day,
+  applicationId,
+  interactionToken,
+}: ApplyStalenessGateOptions): Promise<DiscordResponse | null> {
+  const regionName = regionDisplayName(region);
+
+  if (forceFetch) {
+    return runRefetchThenCommand({
+      command,
+      dbUser,
+      region,
+      discordUserId,
+      applicationId,
+      interactionToken,
+      day,
+    });
+  }
+
+  try {
+    const lastFetchedAt = await getLatestSnapshotFetchedAt(dbUser.id, region);
+    if (lastFetchedAt && isStale(lastFetchedAt)) {
+      return getStalePromptResponse({
+        command,
+        discordUserId,
+        region,
+        regionName,
+        lastFetchedAt,
+        payload,
+      });
+    }
+  } catch (error) {
+    getLogger().error({ err: error }, 'Staleness check failed, proceeding with command');
+  }
+
+  return null;
+}
+
+export interface RunRefetchThenCommandOptions {
+  command: StaleCommand;
+  dbUser: ResolvedUser;
+  region: Region;
+  discordUserId: string;
+  applicationId: string;
+  interactionToken: string;
+  day?: string;
+}
+
+/**
+ * Refetch from maimai DX NET, then run the given command. Shared by the
+ * `forceFetch` slash-option path and the staleness "Refetch and continue"
+ * button path. Returns a deferred response immediately.
+ */
+export function runRefetchThenCommand({
+  command,
+  dbUser,
+  region,
+  discordUserId,
+  applicationId,
+  interactionToken,
+  day,
+}: RunRefetchThenCommandOptions): DiscordResponse {
+  const deferredResponse = createDeferredResponse();
+
+  const backgroundTask = (async () => {
+    const regionName = regionDisplayName(region);
+    try {
+      await editDiscordMessage(applicationId, interactionToken, {
+        embeds: [{
+          title: `🔄 Refetching ${regionName} Data`,
+          description: `<@${discordUserId}> Refetching from maimai DX NET, then continuing...`,
+          color: DISCORD_COLORS.YELLOW,
+          footer: { text: 'tomomai ともマイ • maimai DX score tracker' },
+          timestamp: new Date().toISOString(),
+        }],
+        components: [],
+      });
+
+      const ok = await runFetchSession({
+        userId: dbUser.id,
+        username: dbUser.username ?? dbUser.name,
+        region,
+        regionName,
+        discordUserId,
+        applicationId,
+        interactionToken,
+        onCompleted: async () => { /* command runs next */ },
+      });
+
+      if (!ok) return; // runFetchSession already posted the error/timeout embed
+
+      await runCommand(command, dbUser, region, discordUserId, applicationId, interactionToken, day);
+    } catch (error) {
+      getLogger().error({ err: error }, 'Error in refetch-then-command');
+      await editDiscordMessage(applicationId, interactionToken, {
+        embeds: [{
+          title: '❌ Error',
+          description: `<@${discordUserId}> An error occurred while refetching. Please try again later.`,
+          color: DISCORD_COLORS.RED,
+          footer: { text: 'tomomai ともマイ • maimai DX score tracker' },
+          timestamp: new Date().toISOString(),
+        }],
+      });
+    }
+  })();
+
+  waitUntil(backgroundTask);
+
+  return deferredResponse;
+}
+
+export interface HandleStalenessChoiceOptions {
+  command: StaleCommand;
+  discordUserId: string;
+  region: Region;
+  refetch: boolean;
+  payload: string;
+  applicationId: string;
+  interactionToken: string;
+}
+
+/**
+ * Handle a click on the staleness prompt buttons. `payload` carries the
+ * `/daily` day (empty string = default day).
+ */
+export async function handleStalenessChoice({
+  command,
+  discordUserId,
+  region,
+  refetch,
+  payload,
+  applicationId,
+  interactionToken,
+}: HandleStalenessChoiceOptions): Promise<DiscordResponse> {
+  if (!discordUserId) {
+    return createErrorResponse('Unable to identify Discord user.');
+  }
+
+  const dbUser = await resolveDbUser(discordUserId);
+  if (!dbUser) {
+    return createErrorResponse('Unable to find your account. Please try again.');
+  }
+
+  const resolvedRegion = resolveRegion(region, dbUser.region);
+  const day = command === 'daily' && payload ? payload : undefined;
+
+  if (refetch) {
+    return runRefetchThenCommand({
+      command,
+      dbUser,
+      region: resolvedRegion,
+      discordUserId,
+      applicationId,
+      interactionToken,
+      day,
+    });
+  }
+
+  const deferredResponse = createDeferredResponse();
+
+  const backgroundTask = (async () => {
+    try {
+      await editDiscordMessage(applicationId, interactionToken, {
+        embeds: [{
+          title: '⏳ Loading...',
+          description: `<@${discordUserId}> Continuing with your current data...`,
+          color: DISCORD_COLORS.BLURPLE,
+          footer: { text: 'tomomai ともマイ • maimai DX score tracker' },
+          timestamp: new Date().toISOString(),
+        }],
+        components: [],
+      });
+      await runCommand(command, dbUser, resolvedRegion, discordUserId, applicationId, interactionToken, day);
+    } catch (error) {
+      getLogger().error({ err: error }, 'Error in staleness continue path');
+      await editDiscordMessage(applicationId, interactionToken, {
+        embeds: [{
+          title: '❌ Error',
+          description: `<@${discordUserId}> An error occurred. Please try again later.`,
+          color: DISCORD_COLORS.RED,
+          footer: { text: 'tomomai ともマイ • maimai DX score tracker' },
+          timestamp: new Date().toISOString(),
+        }],
+      });
+    }
+  })();
+
+  waitUntil(backgroundTask);
+
+  return deferredResponse;
+}

--- a/apps/main/src/lib/discord/i18n.ts
+++ b/apps/main/src/lib/discord/i18n.ts
@@ -1,0 +1,78 @@
+import enUS from '../../../messages/discord/en-US.json';
+import enGB from '../../../messages/discord/en-GB.json';
+import ja from '../../../messages/discord/ja.json';
+import zhCN from '../../../messages/discord/zh-CN.json';
+import zhTW from '../../../messages/discord/zh-TW.json';
+import ko from '../../../messages/discord/ko.json';
+import { getLogger } from '@/lib/request-logger';
+
+export type DiscordLocale = 'en-US' | 'en-GB' | 'ja' | 'zh-CN' | 'zh-TW' | 'ko';
+
+const SUPPORTED_DISCORD_LOCALES = new Set<string>([
+  'en-US', 'en-GB', 'ja', 'zh-CN', 'zh-TW', 'ko',
+]);
+
+const MESSAGES: Record<string, unknown> = {
+  'en-US': enUS,
+  'en-GB': enGB,
+  'ja': ja,
+  'zh-CN': zhCN,
+  'zh-TW': zhTW,
+  'ko': ko,
+};
+
+export const DEFAULT_DISCORD_LOCALE: DiscordLocale = 'en-US';
+
+const warnedKeys = new Set<string>();
+
+export function resolveDiscordLocale(locale: string | undefined): DiscordLocale {
+  if (locale && SUPPORTED_DISCORD_LOCALES.has(locale)) return locale as DiscordLocale;
+  return DEFAULT_DISCORD_LOCALE;
+}
+
+function lookup(obj: unknown, segments: string[]): unknown {
+  let cur: unknown = obj;
+  for (const seg of segments) {
+    if (cur && typeof cur === 'object' && seg in (cur as Record<string, unknown>)) {
+      cur = (cur as Record<string, unknown>)[seg];
+    } else {
+      return undefined;
+    }
+  }
+  return cur;
+}
+
+function interpolate(template: string, params?: Record<string, string | number>): string {
+  if (!params) return template;
+  return template.replace(/\{(\w+)\}/g, (_, key: string) =>
+    Object.prototype.hasOwnProperty.call(params, key) ? String(params[key]) : `{${key}}`,
+  );
+}
+
+export function t(
+  locale: string | undefined,
+  key: string,
+  params?: Record<string, string | number>,
+): string {
+  const resolved = resolveDiscordLocale(locale);
+  const messages = MESSAGES[resolved] ?? MESSAGES[DEFAULT_DISCORD_LOCALE];
+  const value = lookup(messages, key.split('.'));
+
+  if (typeof value === 'string') return interpolate(value, params);
+
+  // Fall back to en-US, then to the key itself.
+  const fallback = lookup(MESSAGES[DEFAULT_DISCORD_LOCALE], key.split('.'));
+  if (typeof fallback === 'string') return interpolate(fallback, params);
+
+  if (!warnedKeys.has(key)) {
+    warnedKeys.add(key);
+    getLogger().warn({ key, locale: resolved }, 'Missing Discord i18n key');
+  }
+  return key;
+}
+
+export type Translator = (key: string, params?: Record<string, string | number>) => string;
+
+export function getDiscordTranslator(locale: string | undefined): Translator {
+  return (key, params) => t(locale, key, params);
+}

--- a/apps/main/src/lib/discord/image-utils.ts
+++ b/apps/main/src/lib/discord/image-utils.ts
@@ -351,8 +351,11 @@ export async function generateAndSendDailyPlaysImage({
   try {
     const result = await prepareDailyPlaysData(userId, region, day);
     if (result.type === 'error') {
+      const content = day
+        ? t(locale, 'daily.noPlaysDay', { userId: discordUserId, day, regionName })
+        : t(locale, 'daily.noPlays', { userId: discordUserId, regionName });
       await editDiscordMessage(applicationId, interactionToken, {
-        content: t(locale, 'daily.noPlays', { userId: discordUserId, day: day ? ` for ${day}` : '', regionName }),
+        content,
       });
       return;
     }

--- a/apps/main/src/lib/discord/image-utils.ts
+++ b/apps/main/src/lib/discord/image-utils.ts
@@ -15,6 +15,7 @@ import { Image, loadImage } from 'skia-canvas';
 import { getRatingImageUrl } from '@/lib/rating-calculator';
 import { getLogoUrl, getTypeBadgeUrl } from '@/lib/utils';
 import { DIFFICULTY_ENUM } from '@/lib/db/types';
+import { t } from './i18n';
 
 export interface ImageGenerationOptions {
   summary: ProfileSummary;
@@ -24,6 +25,7 @@ export interface ImageGenerationOptions {
   interactionToken: string;
   username: string;
   showGeneratingStatus?: boolean;
+  locale?: string;
 }
 
 export async function generateAndSendProfileImage({
@@ -34,21 +36,22 @@ export async function generateAndSendProfileImage({
   interactionToken,
   username,
   showGeneratingStatus = false,
+  locale,
 }: ImageGenerationOptions): Promise<void> {
   // Show image generation status if requested
   if (showGeneratingStatus) {
     await editDiscordMessage(applicationId, interactionToken, {
       embeds: [{
-        title: `🔄 Fetching ${regionName} Data`,
-        description: `<@${discordUserId}> Data fetch completed, generating profile image...`,
+        title: t(locale, 'fetch.generatingImage.title', { regionName }),
+        description: t(locale, 'fetch.generatingImage.description', { userId: discordUserId }),
         color: DISCORD_COLORS.YELLOW,
         fields: [{
-          name: '📊 Status',
-          value: '⏳ Generating Profile Image',
+          name: t(locale, 'fetch.generatingImage.status'),
+          value: t(locale, 'fetch.generatingImage.statusValue'),
           inline: false,
         }],
         footer: {
-          text: 'tomomai ともマイ • maimai DX score tracker',
+          text: t(locale, 'common.footer'),
         },
         timestamp: new Date().toISOString(),
       }],
@@ -61,7 +64,7 @@ export async function generateAndSendProfileImage({
     : 'http://localhost:3000';
   const profileUrl = `${baseUrl}/profile/${username}/`;
 
-  const content = formatProfileSummaryContent(discordUserId, summary, regionName);
+  const content = formatProfileSummaryContent(discordUserId, summary, regionName, locale);
 
   const components = [
     {
@@ -70,7 +73,7 @@ export async function generateAndSendProfileImage({
         {
           type: 2, // Button
           style: 5, // Link style
-          label: '🔗 View Full Profile',
+          label: t(locale, 'profile.viewFullProfile'),
           url: profileUrl,
         },
       ],
@@ -105,6 +108,7 @@ export interface CreditImageOptions {
   applicationId: string;
   interactionToken: string;
   skip?: number;
+  locale?: string;
 }
 
 export async function generateAndSendCreditImage({
@@ -114,23 +118,24 @@ export async function generateAndSendCreditImage({
   applicationId,
   interactionToken,
   skip = 0,
+  locale,
 }: CreditImageOptions): Promise<void> {
-  const regionName = regionDisplayName(region);
+  const regionName = regionDisplayName(region, locale);
 
   try {
     // Show loading message
     await editDiscordMessage(applicationId, interactionToken, {
       embeds: [{
-        title: `🔄 Loading ${regionName} Recent Plays`,
-        description: `<@${discordUserId}> Generating your recent play image...`,
+        title: t(locale, 'recents.loading.title', { regionName }),
+        description: t(locale, 'recents.loading.description', { userId: discordUserId }),
         color: DISCORD_COLORS.BLURPLE,
         fields: [{
-          name: '📊 Status',
-          value: '⏳ Generating Image',
+          name: t(locale, 'recents.loading.status'),
+          value: t(locale, 'recents.loading.statusValue'),
           inline: false,
         }],
         footer: {
-          text: 'tomomai ともマイ • maimai DX score tracker',
+          text: t(locale, 'common.footer'),
         },
         timestamp: new Date().toISOString(),
       }],
@@ -166,13 +171,13 @@ export async function generateAndSendCreditImage({
     if (prepareDataResult.type === "error") {
       await editDiscordMessage(applicationId, interactionToken, {
         embeds: [{
-          title: '📊 No Recent Plays Found',
+          title: t(locale, 'recents.noPlays.title'),
           description: skip === 0
-            ? `You don't have any recent ${regionName} region plays yet!`
-            : `No more plays found.`,
+            ? t(locale, 'recents.noPlays.description', { regionName })
+            : t(locale, 'recents.noPlays.noMore'),
           color: DISCORD_COLORS.YELLOW,
           footer: {
-            text: 'tomomai ともマイ • maimai DX score tracker',
+            text: t(locale, 'common.footer'),
           },
         }],
       });
@@ -243,7 +248,7 @@ export async function generateAndSendCreditImage({
 
     // Plain content line, mirroring /profile and /daily styling
     const playedUnix = Math.floor(credit.playedAt.getTime() / 1000);
-    const content = `<@${discordUserId}> Here are your recent plays at <t:${playedUnix}:f> (${regionName})`;
+    const content = t(locale, 'recents.content', { userId: discordUserId, unix: playedUnix, regionName });
 
     // Create navigation buttons
     const components = [
@@ -253,7 +258,7 @@ export async function generateAndSendCreditImage({
           {
             type: 2, // BUTTON
             custom_id: `recents_${discordUserId}_${region}_${skip - 1}`,
-            label: 'Newer Play',
+            label: t(locale, 'recents.newerPlay'),
             style: 2, // SECONDARY
             emoji: {
               name: '⬅️'
@@ -263,7 +268,7 @@ export async function generateAndSendCreditImage({
           {
             type: 2, // BUTTON
             custom_id: `recents_${discordUserId}_${region}_${skip + 1}`,
-            label: 'Older Play',
+            label: t(locale, 'recents.olderPlay'),
             style: 2, // SECONDARY
             emoji: {
               name: '➡️'
@@ -288,11 +293,11 @@ export async function generateAndSendCreditImage({
     getLogger().error({ err: error }, 'Error generating credit image');
     await editDiscordMessage(applicationId, interactionToken, {
       embeds: [{
-        title: '❌ Error',
-        description: `Failed to generate image: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        title: t(locale, 'recents.error.title'),
+        description: t(locale, 'recents.error.description', { message: error instanceof Error ? error.message : 'Unknown error' }),
         color: DISCORD_COLORS.RED,
         footer: {
-          text: 'tomomai ともマイ • maimai DX score tracker',
+          text: t(locale, 'common.footer'),
         },
       }],
     });
@@ -306,6 +311,7 @@ export interface DailyPlaysImageOptions {
   day?: string;
   applicationId: string;
   interactionToken: string;
+  locale?: string;
 }
 
 async function editDiscordMessageWithImageOnly(
@@ -338,14 +344,15 @@ export async function generateAndSendDailyPlaysImage({
   day,
   applicationId,
   interactionToken,
+  locale,
 }: DailyPlaysImageOptions): Promise<void> {
-  const regionName = regionDisplayName(region);
+  const regionName = regionDisplayName(region, locale);
 
   try {
     const result = await prepareDailyPlaysData(userId, region, day);
     if (result.type === 'error') {
       await editDiscordMessage(applicationId, interactionToken, {
-        content: `<@${discordUserId}> No plays found${day ? ` for ${day}` : ''} (${regionName}).`,
+        content: t(locale, 'daily.noPlays', { userId: discordUserId, day: day ? ` for ${day}` : '', regionName }),
       });
       return;
     }
@@ -375,14 +382,14 @@ export async function generateAndSendDailyPlaysImage({
     await editDiscordMessageWithImageOnly(
       applicationId,
       interactionToken,
-      `<@${discordUserId}> Daily plays for **${resolvedDay}** (${regionName})`,
+      t(locale, 'daily.content', { userId: discordUserId, day: resolvedDay, regionName }),
       imageBuffer,
       `maimai-daily-${resolvedDay}.jpg`,
     );
   } catch (error) {
     getLogger().error({ err: error }, 'Error generating daily plays image');
     await editDiscordMessage(applicationId, interactionToken, {
-      content: `<@${discordUserId}> ❌ Failed to generate daily plays image.`,
+      content: t(locale, 'daily.failed', { userId: discordUserId }),
     });
   }
 }

--- a/apps/main/src/lib/discord/region.ts
+++ b/apps/main/src/lib/discord/region.ts
@@ -3,6 +3,7 @@ import { splitSongs } from '@/lib/rating-calculator';
 import type { Region, SongWithScore } from '@/lib/types';
 import { fetchLatestSnapshotData } from '@/server/queries/snapshots';
 import { getRatingComment } from './responses';
+import { t } from './i18n';
 
 const REGION_NAMES: Record<Region, string> = {
   intl: 'International',
@@ -10,7 +11,10 @@ const REGION_NAMES: Record<Region, string> = {
   cn: 'China',
 };
 
-export function regionDisplayName(region: Region): string {
+export function regionDisplayName(region: Region, locale?: string): string {
+  if (locale) {
+    return t(locale, `regions.${region}`);
+  }
   return REGION_NAMES[region] ?? region;
 }
 
@@ -78,14 +82,23 @@ export async function getProfileSummary(userId: string, region: Region): Promise
 export function formatProfileSummaryContent(
   discordUserId: string,
   summary: ProfileSummary,
-  regionName?: string
+  regionName?: string,
+  locale?: string,
 ): string {
   const comment = getRatingComment(summary.rating);
   const newAvg = summary.newCount > 0 ? (summary.newRating / summary.newCount).toFixed(1) : '0.0';
   const oldAvg = summary.oldCount > 0 ? (summary.oldRating / summary.oldCount).toFixed(1) : '0.0';
   const regionSuffix = regionName ? ` (${regionName})` : '';
-  return (
-    `<@${discordUserId}> ${comment}, you only have **${summary.rating}** rating! 😤${regionSuffix}\n` +
-    `-# New Charts: ${summary.newRating} (avg: ${newAvg}) - Old Charts: ${summary.oldRating} (avg: ${oldAvg}) - Stars: ${summary.stars} - Total Plays: ${summary.totalPlayCount}`
-  );
+  return t(locale, 'profile.content', {
+    userId: discordUserId,
+    comment,
+    rating: String(summary.rating),
+    regionSuffix,
+    newRating: String(summary.newRating),
+    newAvg,
+    oldRating: String(summary.oldRating),
+    oldAvg,
+    stars: String(summary.stars),
+    totalPlays: String(summary.totalPlayCount),
+  });
 }

--- a/apps/main/src/lib/discord/responses.ts
+++ b/apps/main/src/lib/discord/responses.ts
@@ -2,6 +2,7 @@ import { InteractionResponseType, InteractionResponseFlags } from 'discord-inter
 import { FETCH_STATUS_ENUM } from '../db/types';
 import { FETCH_STATES } from '../fetch-states';
 import { resolveBaseUrl } from '../base-url';
+import { t } from './i18n';
 
 export interface DiscordEmbed {
   title?: string;
@@ -154,21 +155,21 @@ export function getRatingComment(rating: number): string {
 }
 
 // Standard response templates
-export function createNotRegisteredResponse(): DiscordResponse {
+export function createNotRegisteredResponse(locale?: string): DiscordResponse {
   return {
     type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
     data: {
       embeds: [{
-        title: '❌ Not Registered',
-        description: `You haven't linked your Discord account to tomomai yet!`,
+        title: t(locale, 'common.notRegistered.title'),
+        description: t(locale, 'common.notRegistered.description'),
         color: DISCORD_COLORS.RED,
         fields: [{
-          name: '🔗 Get Started',
-          value: `[Visit tomomai ともマイ](${resolveBaseUrl()}/) to sign in with Discord and start tracking your scores!`,
+          name: t(locale, 'common.notRegistered.getStarted.name'),
+          value: t(locale, 'common.notRegistered.getStarted.value', { baseUrl: resolveBaseUrl() }),
           inline: false,
         }],
         footer: {
-          text: 'tomomai ともマイ • maimai DX score tracker',
+          text: t(locale, 'common.footer'),
         },
       }],
       flags: InteractionResponseFlags.EPHEMERAL,
@@ -176,21 +177,21 @@ export function createNotRegisteredResponse(): DiscordResponse {
   };
 }
 
-export function createNoDataResponse(regionName: string): DiscordResponse {
+export function createNoDataResponse(regionName: string, locale?: string): DiscordResponse {
   return {
     type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
     data: {
       embeds: [{
-        title: '📊 No Data Found',
-        description: `You don't have any ${regionName} region data yet!`,
+        title: t(locale, 'common.noData.title'),
+        description: t(locale, 'common.noData.description', { regionName }),
         color: DISCORD_COLORS.YELLOW,
         fields: [{
-          name: '🎯 Import Your Scores',
-          value: `[Visit tomomai ともマイ](${resolveBaseUrl()}/) to import your ${regionName} maimai DX scores!`,
+          name: t(locale, 'common.noData.import.name'),
+          value: t(locale, 'common.noData.import.value', { baseUrl: resolveBaseUrl(), regionName }),
           inline: false,
         }],
         footer: {
-          text: 'tomomai ともマイ • maimai DX score tracker',
+          text: t(locale, 'common.footer'),
         },
       }],
       flags: InteractionResponseFlags.EPHEMERAL,
@@ -198,7 +199,7 @@ export function createNoDataResponse(regionName: string): DiscordResponse {
   };
 }
 
-export function createErrorResponse(message: string): DiscordResponse {
+export function createErrorResponse(message: string, locale?: string): DiscordResponse {
   return {
     type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
     data: {
@@ -220,11 +221,11 @@ export function createPongResponse(): DiscordResponse {
   };
 }
 
-export function createUnknownCommandResponse(): DiscordResponse {
+export function createUnknownCommandResponse(locale?: string): DiscordResponse {
   return {
     type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
     data: {
-      content: 'Unknown command',
+      content: t(locale, 'common.error.unknownCommand'),
       flags: InteractionResponseFlags.EPHEMERAL,
     },
   };

--- a/apps/main/src/lib/discord/staleness.ts
+++ b/apps/main/src/lib/discord/staleness.ts
@@ -1,6 +1,7 @@
 import { InteractionResponseType } from 'discord-interactions';
 import type { DiscordResponse } from './responses';
 import { DISCORD_COLORS } from './responses';
+import { t } from './i18n';
 
 /** Prompt the user when their data is older than this. */
 export const STALE_THRESHOLD_MS = 1 * 60 * 60 * 1000;
@@ -12,36 +13,36 @@ export function isStale(lastFetchedAt: Date, now: number = Date.now()): boolean 
 }
 
 /** Humanize an elapsed duration as "3 days", "2 hours", "5 minutes", "just now". */
-export function formatRelativeAge(past: Date, now: number = Date.now()): string {
+export function formatRelativeAge(past: Date, locale?: string, now: number = Date.now()): string {
   const ms = Math.max(0, now - past.getTime());
   const sec = Math.floor(ms / 1000);
-  if (sec < 45) return 'just now';
+  if (sec < 45) return t(locale, 'age.justNow');
   const min = Math.floor(sec / 60);
-  if (min < 60) return min === 1 ? '1 minute' : `${min} minutes`;
+  if (min < 60) return min === 1 ? t(locale, 'age.minute') : t(locale, 'age.minutes', { count: min });
   const hr = Math.floor(min / 60);
-  if (hr < 24) return hr === 1 ? '1 hour' : `${hr} hours`;
+  if (hr < 24) return hr === 1 ? t(locale, 'age.hour') : t(locale, 'age.hours', { count: hr });
   const day = Math.floor(hr / 24);
-  if (day < 30) return day === 1 ? '1 day' : `${day} days`;
+  if (day < 30) return day === 1 ? t(locale, 'age.day') : t(locale, 'age.days', { count: day });
   const month = Math.floor(day / 30);
-  if (month < 12) return month === 1 ? '1 month' : `${month} months`;
+  if (month < 12) return month === 1 ? t(locale, 'age.month') : t(locale, 'age.months', { count: month });
   const year = Math.floor(day / 365);
-  return year === 1 ? '1 year' : `${year} years`;
+  return year === 1 ? t(locale, 'age.year') : t(locale, 'age.years', { count: year });
 }
 
-function commandSpecificLine(command: StaleCommand, payload: string): string {
+function commandSpecificLine(command: StaleCommand, payload: string, locale?: string): string {
   switch (command) {
     case 'profile':
-      return 'Do you still want to view your profile?';
+      return t(locale, 'staleness.cmdLine.profile');
     case 'recents':
-      return 'Do you still want to view your recent plays?';
+      return t(locale, 'staleness.cmdLine.recents');
     case 'recommend':
-      return 'Do you still want to view your recommendations?';
+      return t(locale, 'staleness.cmdLine.recommend');
     case 'daily':
       return payload
-        ? `Do you still want to generate your daily plays for ${payload}?`
-        : 'Do you still want to generate your daily plays?';
+        ? t(locale, 'staleness.cmdLine.daily', { day: payload })
+        : t(locale, 'staleness.cmdLine.dailyDefault');
     default:
-      return 'Do you want to continue?';
+      return t(locale, 'staleness.cmdLine.default');
   }
 }
 
@@ -52,6 +53,7 @@ export interface StalePromptOptions {
   regionName: string;
   lastFetchedAt: Date;
   payload: string;
+  locale?: string;
 }
 
 /**
@@ -65,11 +67,11 @@ export function getStalePromptResponse({
   regionName,
   lastFetchedAt,
   payload,
+  locale,
 }: StalePromptOptions): DiscordResponse {
-  const age = formatRelativeAge(lastFetchedAt);
-  const description =
-    `<@${discordUserId}> Your last **${regionName}** fetch was **${age}** ago.\n` +
-    commandSpecificLine(command, payload);
+  const age = formatRelativeAge(lastFetchedAt, locale);
+  const cmdLine = commandSpecificLine(command, payload, locale);
+  const description = t(locale, 'staleness.description', { userId: discordUserId, regionName, age, cmdLine });
 
   const customId = (choice: 0 | 1) =>
     `staleness_${command}_${discordUserId}_${region}_${choice}_${payload}`;
@@ -78,11 +80,11 @@ export function getStalePromptResponse({
     type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
     data: {
       embeds: [{
-        title: '⏳ Stale Data',
+        title: t(locale, 'staleness.title'),
         description,
         color: DISCORD_COLORS.YELLOW,
         footer: {
-          text: 'tomomai ともマイ • maimai DX score tracker',
+          text: t(locale, 'common.footer'),
         },
         timestamp: new Date().toISOString(),
       }],
@@ -92,13 +94,13 @@ export function getStalePromptResponse({
           {
             type: 2, // BUTTON
             style: 2, // SECONDARY
-            label: 'Continue',
+            label: t(locale, 'staleness.buttons.continue'),
             custom_id: customId(0),
           },
           {
             type: 2, // BUTTON
             style: 1, // PRIMARY
-            label: 'Refetch and continue',
+            label: t(locale, 'staleness.buttons.refetchAndContinue'),
             custom_id: customId(1),
           },
         ],

--- a/apps/main/src/lib/discord/staleness.ts
+++ b/apps/main/src/lib/discord/staleness.ts
@@ -1,0 +1,108 @@
+import { InteractionResponseType } from 'discord-interactions';
+import type { DiscordResponse } from './responses';
+import { DISCORD_COLORS } from './responses';
+
+/** Prompt the user when their data is older than this. */
+export const STALE_THRESHOLD_MS = 1 * 60 * 60 * 1000;
+
+export type StaleCommand = 'profile' | 'recents' | 'recommend' | 'daily';
+
+export function isStale(lastFetchedAt: Date, now: number = Date.now()): boolean {
+  return now - lastFetchedAt.getTime() > STALE_THRESHOLD_MS;
+}
+
+/** Humanize an elapsed duration as "3 days", "2 hours", "5 minutes", "just now". */
+export function formatRelativeAge(past: Date, now: number = Date.now()): string {
+  const ms = Math.max(0, now - past.getTime());
+  const sec = Math.floor(ms / 1000);
+  if (sec < 45) return 'just now';
+  const min = Math.floor(sec / 60);
+  if (min < 60) return min === 1 ? '1 minute' : `${min} minutes`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return hr === 1 ? '1 hour' : `${hr} hours`;
+  const day = Math.floor(hr / 24);
+  if (day < 30) return day === 1 ? '1 day' : `${day} days`;
+  const month = Math.floor(day / 30);
+  if (month < 12) return month === 1 ? '1 month' : `${month} months`;
+  const year = Math.floor(day / 365);
+  return year === 1 ? '1 year' : `${year} years`;
+}
+
+function commandSpecificLine(command: StaleCommand, payload: string): string {
+  switch (command) {
+    case 'profile':
+      return 'Do you still want to view your profile?';
+    case 'recents':
+      return 'Do you still want to view your recent plays?';
+    case 'recommend':
+      return 'Do you still want to view your recommendations?';
+    case 'daily':
+      return payload
+        ? `Do you still want to generate your daily plays for ${payload}?`
+        : 'Do you still want to generate your daily plays?';
+    default:
+      return 'Do you want to continue?';
+  }
+}
+
+export interface StalePromptOptions {
+  command: StaleCommand;
+  discordUserId: string;
+  region: string;
+  regionName: string;
+  lastFetchedAt: Date;
+  payload: string;
+}
+
+/**
+ * Build the "your last fetch was X ago" message with Continue / Refetch
+ * buttons. `payload` is currently only used by `/daily` to carry the day.
+ */
+export function getStalePromptResponse({
+  command,
+  discordUserId,
+  region,
+  regionName,
+  lastFetchedAt,
+  payload,
+}: StalePromptOptions): DiscordResponse {
+  const age = formatRelativeAge(lastFetchedAt);
+  const description =
+    `<@${discordUserId}> Your last **${regionName}** fetch was **${age}** ago.\n` +
+    commandSpecificLine(command, payload);
+
+  const customId = (choice: 0 | 1) =>
+    `staleness_${command}_${discordUserId}_${region}_${choice}_${payload}`;
+
+  return {
+    type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+    data: {
+      embeds: [{
+        title: '⏳ Stale Data',
+        description,
+        color: DISCORD_COLORS.YELLOW,
+        footer: {
+          text: 'tomomai ともマイ • maimai DX score tracker',
+        },
+        timestamp: new Date().toISOString(),
+      }],
+      components: [{
+        type: 1, // ACTION_ROW
+        components: [
+          {
+            type: 2, // BUTTON
+            style: 2, // SECONDARY
+            label: 'Continue',
+            custom_id: customId(0),
+          },
+          {
+            type: 2, // BUTTON
+            style: 1, // PRIMARY
+            label: 'Refetch and continue',
+            custom_id: customId(1),
+          },
+        ],
+      }],
+    },
+  };
+}

--- a/apps/main/src/lib/discord/staleness.ts
+++ b/apps/main/src/lib/discord/staleness.ts
@@ -24,7 +24,7 @@ export function formatRelativeAge(past: Date, locale?: string, now: number = Dat
   const day = Math.floor(hr / 24);
   if (day < 30) return day === 1 ? t(locale, 'age.day') : t(locale, 'age.days', { count: day });
   const month = Math.floor(day / 30);
-  if (month < 12) return month === 1 ? t(locale, 'age.month') : t(locale, 'age.months', { count: month });
+  if (day < 365) return month === 1 ? t(locale, 'age.month') : t(locale, 'age.months', { count: month });
   const year = Math.floor(day / 365);
   return year === 1 ? t(locale, 'age.year') : t(locale, 'age.years', { count: year });
 }

--- a/apps/main/src/server/queries/snapshots.ts
+++ b/apps/main/src/server/queries/snapshots.ts
@@ -147,6 +147,28 @@ export async function fetchSnapshotData(
   };
 }
 
+/**
+ * Return the `fetchedAt` of the user's newest snapshot for a region, or null
+ * if they have none. Cheap single-column query used for staleness checks.
+ */
+export async function getLatestSnapshotFetchedAt(
+  userId: string,
+  region: Region,
+): Promise<Date | null> {
+  const [row] = await db
+    .select({ fetchedAt: userSnapshots.fetchedAt })
+    .from(userSnapshots)
+    .where(
+      and(
+        eq(userSnapshots.userId, userId),
+        eq(userSnapshots.region, region),
+      ),
+    )
+    .orderBy(desc(userSnapshots.fetchedAt))
+    .limit(1);
+  return row?.fetchedAt ?? null;
+}
+
 export async function fetchLatestSnapshotData(userId: string, region: Region) {
   const snapshot = await db
     .select()


### PR DESCRIPTION
Staleness-aware refetch prompts, optional `fetch` option, and full i18n for Discord commands, in three commits.

## `feat(main/discord): staleness-aware refetch prompt and fetch option`

Add a staleness gate to `/profile`, `/recents`, `/recommend`, `/daily`: when the user's latest snapshot for the region is older than **1 hour**, post a public prompt with **Continue** / **Refetch and continue** buttons instead of running the command immediately.
- Continue runs the command on existing data; Refetch runs a fetch session, then the command.
- Button clicks route through a new `staleness_<cmd>_<userId>_<region>_<choice>_<payload>` component id.

Also add an optional boolean `fetch` option to the same four commands that forces a refetch-then-run with no prompt, and a light `getLatestSnapshotFetchedAt` query so the gate doesn't load scores/events.

Refactor: extract `execute<Cmd>` bodies from each handler and a reusable `runFetchSession` (with `onCompleted` callback, returns success boolean) from `/fetch` so the prompt and force-fetch paths share one implementation. `/fetch` itself is unchanged.

## `feat(main/discord): i18n discord messages`

Localize Discord command/prompt UI strings through a standalone custom loader reading per-locale JSON from a new `messages/discord/` directory (outside the `app/[locale]/` routing, so no next-intl request-context coupling).
- Ships `en-US` as source-of-truth plus empty stubs for `en-GB`, `ja`, `zh-CN`, `zh-TW`, `ko` (fallback to en-US until populated).
- Locale resolution: `interaction.locale` (Discord client language) → en-US fallback.
- Covers status embeds, the staleness prompt, per-command content lines, button labels, error messages, region display names, and relative age strings. The rating roast comments are left English for now.
- `custom_id` tokens and autocomplete values stay locale-independent.

## `fix(main/discord): native boolean fetch option, profile error guard, age formatter`

Review fixes on the above:
- `getBooleanParam` only matched the string `'true'`, so Discord's native boolean for the type-5 `fetch` option was misread as false. Widen `CommandOption.value` to `string | boolean` and accept both.
- `executeProfileCommand` guarded only `generateAndSendProfileImage`, so a rejection from the initial `editDiscordMessage` or `getProfileSummary` escaped the worker and left the interaction stuck on loading. Wrap the whole body and edit `@original` with a fallback on any failure.
- `formatRelativeAge` returned "0 years" for 360–364 days because it entered the year branch before a full year elapsed. Use `day < 365` as the month cutoff so it renders "12 months" until a full year.

---

**Before deploying**, re-register slash commands so the new `fetch` option appears:
```
node apps/main/scripts/register-discord-commands.js
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localized Discord support across multiple languages.
  * Introduced staleness prompts with options to continue or refetch, plus a new refetch choice for supported commands.
  * Improved command flows for profile, recents, recommendations, daily plays, fetch, and invite with locale-aware messaging.

* **Bug Fixes**
  * Reduced outdated results by checking data freshness before showing command output.
  * Improved error, loading, and empty-state messages for clearer user feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->