### PR TITLE
perf(main/db): widen ISR windows and add browser cache headers

### DIFF
--- a/apps/main/src/app/[locale]/db/@detail/[type]/[slug]/page.tsx
+++ b/apps/main/src/app/[locale]/db/@detail/[type]/[slug]/page.tsx
@@ -4,7 +4,13 @@ import { safeDecodeURIComponent } from "@/lib/utils";
 import { getTranslations } from "next-intl/server";
 
 // Match the parent [slug] route's ISR mode.
-export const revalidate = 3600;
+export const revalidate = 86400;
+
+export async function headers() {
+  return {
+    "cache-control": "public, max-age=3600, stale-while-revalidate=86400",
+  };
+}
 
 export function generateStaticParams() {
   return [];

--- a/apps/main/src/app/[locale]/db/[type]/[slug]/page.tsx
+++ b/apps/main/src/app/[locale]/db/[type]/[slug]/page.tsx
@@ -8,7 +8,13 @@ import { resolveBaseUrl } from "@/lib/base-url";
 import { safeDecodeURIComponent } from "@/lib/utils";
 
 // On-demand ISR.
-export const revalidate = 3600;
+export const revalidate = 86400;
+
+export async function headers() {
+  return {
+    "cache-control": "public, max-age=3600, stale-while-revalidate=86400",
+  };
+}
 
 export function generateStaticParams() {
   return [];

--- a/apps/main/src/app/[locale]/db/[type]/page.tsx
+++ b/apps/main/src/app/[locale]/db/[type]/page.tsx
@@ -8,7 +8,13 @@ import { buildAlternates, openGraphLocales, ogImageUrl, localizePath } from "@/l
 import { DB_TYPES } from "@/lib/db/types";
 
 // On-demand ISR.
-export const revalidate = 3600;
+export const revalidate = 10800;
+
+export async function headers() {
+  return {
+    "cache-control": "public, max-age=3600, stale-while-revalidate=86400",
+  };
+}
 
 export function generateStaticParams() {
   return DB_TYPES.filter((type) => type !== "posts").map((type) => ({ type }));


### PR DESCRIPTION
- [type]/[slug] and @detail/[type]/[slug]: revalidate 1h -> 1d (chart data is static; these are the hottest pages)
- [type] list: revalidate 1h -> 3h (new charts propagate within hours)
- add cache-control: public, max-age=3600, stale-while-revalidate=86400 to all three so returning visitors reuse HTML for 1h then SWR for 1d

HTML is fully public (no userId server-side); per-user scores are layered in client-side, so browser caching leaks nothing.