### PR TITLE
fix(main/profile): fix tab-switch blank and static-render bailout on /profile

### DIFF
--- a/apps/main/src/app/[locale]/profile/[username]/[region]/page.tsx
+++ b/apps/main/src/app/[locale]/profile/[username]/[region]/page.tsx
@@ -8,7 +8,7 @@ import { Metadata } from "next";
 import { defaultFlags } from "@/lib/flags";
 import { resolveBaseUrl } from "@/lib/base-url";
 import { getTranslations } from "next-intl/server";
-import { getLocale } from "@/i18n/locale-server";
+import { getLocale, setStaticLocale } from "@/i18n/locale-server";
 import { buildAlternates, openGraphLocales, breadcrumbJsonLd, ogImageUrl, localizePath } from "@/lib/seo";
 import { safeDecodeURIComponent } from "@/lib/utils";
 
@@ -21,13 +21,15 @@ export function generateStaticParams() {
 
 interface RegionProfilePageProps {
   params: Promise<{
+    locale: string;
     username: string;
     region: string;
   }>;
 }
 
 export async function generateMetadata({ params }: RegionProfilePageProps): Promise<Metadata> {
-  const { username: rawUsername, region } = await params;
+  const { locale: routeLocale, username: rawUsername, region } = await params;
+  await setStaticLocale(routeLocale);
   const username = safeDecodeURIComponent(rawUsername);
 
   const [tMeta, tRegions, locale] = await Promise.all([
@@ -96,7 +98,8 @@ export async function generateMetadata({ params }: RegionProfilePageProps): Prom
 
 
 export default async function RegionProfilePage({ params }: RegionProfilePageProps) {
-  const { username, region } = await params;
+  const { locale: routeLocale, username, region } = await params;
+  await setStaticLocale(routeLocale);
 
   // Validate region
   if (!isRegionEnabledStr(region)) {

--- a/apps/main/src/app/[locale]/profile/[username]/page.tsx
+++ b/apps/main/src/app/[locale]/profile/[username]/page.tsx
@@ -4,16 +4,16 @@ import { createServerSideTRPC } from "@/lib/trpc-server";
 import { TRPCError } from "@trpc/server";
 import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
-import { getLocale } from "@/i18n/locale-server";
+import { getLocale, setStaticLocale } from "@/i18n/locale-server";
 import { buildAlternates, openGraphLocales, localizePath } from "@/lib/seo";
 import { safeDecodeURIComponent } from "@/lib/utils";
 
-export const revalidate = 300;
-export const dynamicParams = true;
-
-export function generateStaticParams() {
-  return [];
-}
+// This route looks up the user's main region from the DB and redirects to
+// /profile/[username]/[region]. It can never serve static HTML (the redirect
+// target is per-user and can change), so it is request-time by nature.
+// Declaring it dynamic avoids the "changed from static to dynamic" bailout
+// that ISR generation logged on every request.
+export const dynamic = "force-dynamic";
 
 interface ProfilePageProps {
   params: Promise<{
@@ -23,7 +23,8 @@ interface ProfilePageProps {
 }
 
 export async function generateMetadata({ params }: ProfilePageProps): Promise<Metadata> {
-  const { username: rawUsername } = await params;
+  const { locale: routeLocale, username: rawUsername } = await params;
+  await setStaticLocale(routeLocale);
   const username = safeDecodeURIComponent(rawUsername);
   const [t, locale] = await Promise.all([
     getTranslations("profileMetadata"),
@@ -58,6 +59,7 @@ export async function generateMetadata({ params }: ProfilePageProps): Promise<Me
 
 export default async function ProfilePage({ params }: ProfilePageProps) {
   const { locale, username } = await params;
+  await setStaticLocale(locale);
 
   try {
     // Get the user's profile to find their main region

--- a/apps/main/src/components/album-card.skeleton.tsx
+++ b/apps/main/src/components/album-card.skeleton.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { Images } from "lucide-react";
+import { Skeleton } from "@tomomai/ui";
+import { useTranslations } from "next-intl";
+
+export function AlbumCardSkeleton() {
+  const t = useTranslations("albums");
+  return (
+    <div className="space-y-6">
+      <h2 className="text-lg font-semibold flex items-center gap-2">
+        <Images className="h-5 w-5" />
+        {t("title")}
+      </h2>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="flex flex-col gap-3 p-4 border rounded-lg">
+            <Skeleton className="w-full aspect-video rounded" />
+            <div className="flex gap-3">
+              <Skeleton className="w-14 h-14 rounded shrink-0 m-1" />
+              <div className="flex-1 min-w-0 space-y-2">
+                <Skeleton className="h-4 w-3/4" />
+                <Skeleton className="h-3 w-1/2" />
+                <Skeleton className="h-2.5 w-8" />
+              </div>
+            </div>
+            <div className="flex items-center gap-2">
+              <Skeleton className="h-3 w-32" />
+              <Skeleton className="h-3 w-24" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/main/src/components/album-card.tsx
+++ b/apps/main/src/components/album-card.tsx
@@ -4,8 +4,8 @@ import { trpc } from "@/lib/trpc-client";
 import { Region } from "@/lib/types";
 import { cn, createSafeMaimaiImageUrl, getTypeBadgeUrl } from "@/lib/utils";
 import { Images, Loader2, AlertCircle, Calendar, MapPin, Music, HardDrive, Info, Trash2 } from "lucide-react";
-import { Skeleton } from "@tomomai/ui";
 import { useTranslations } from "next-intl";
+import { AlbumCardSkeleton } from "./album-card.skeleton";
 
 import { CoverImage } from "@/components/cover-image";
 import { useState, useEffect, useRef, useCallback } from "react";
@@ -118,33 +118,7 @@ export function AlbumCard({ region }: AlbumCardProps) {
   };
 
   if (isLoading && offset === 0) {
-    return (
-      <div className="space-y-6">
-        <h2 className="text-lg font-semibold flex items-center gap-2">
-          <Images className="h-5 w-5" />
-          {t('title')}
-        </h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          {Array.from({ length: 4 }).map((_, i) => (
-            <div key={i} className="flex flex-col gap-3 p-4 border rounded-lg">
-              <Skeleton className="w-full aspect-video rounded" />
-              <div className="flex gap-3">
-                <Skeleton className="w-14 h-14 rounded shrink-0 m-1" />
-                <div className="flex-1 min-w-0 space-y-2">
-                  <Skeleton className="h-4 w-3/4" />
-                  <Skeleton className="h-3 w-1/2" />
-                  <Skeleton className="h-2.5 w-8" />
-                </div>
-              </div>
-              <div className="flex items-center gap-2">
-                <Skeleton className="h-3 w-32" />
-                <Skeleton className="h-3 w-24" />
-              </div>
-            </div>
-          ))}
-        </div>
-      </div>
-    );
+    return <AlbumCardSkeleton />;
   }
 
   if (error) {

--- a/apps/main/src/components/data-content.tsx
+++ b/apps/main/src/components/data-content.tsx
@@ -6,10 +6,17 @@ import { BarChart, Clock, Code, Database, Heart, Image as ImageIcon, Loader2, Ma
 import { useTranslations } from "next-intl";
 import { useState, useEffect } from "react";
 import { useSearchParams } from "next/navigation";
-import { useRouter, usePathname } from "@/i18n/navigation";
 import { InfoCard } from "./info-card";
 import { MinigameCards } from "./minigame-cards";
 import { SongsCard } from "./songs-card";
+import { StatsCardSkeleton } from "./stats-card.skeleton";
+import { RecommendationCardSkeleton } from "./recommendation-card.skeleton";
+import { ExportImageCardSkeleton } from "./export-image-card.skeleton";
+import { HistoryCardSkeleton } from "./history-card.skeleton";
+import { EventsCardSkeleton } from "./events-card.skeleton";
+import { RecentSongsCardSkeleton } from "./recent-songs-card.skeleton";
+import { DeveloperCardSkeleton } from "./developer-card.skeleton";
+import { AlbumCardSkeleton } from "./album-card.skeleton";
 import { Flags } from "@/lib/flags";
 import { AnimatePresence, motion } from "motion/react";
 import { getTransition } from "@/lib/animation-constants";
@@ -19,14 +26,20 @@ import dynamic from "next/dynamic";
 // Tab cards lazy-loaded — only the selected tab's chunk is fetched.
 // SongsCard + InfoCard stay eager because Songs is the default landing tab
 // and InfoCard is small and frequently shown.
-const StatsCard = dynamic(() => import("./stats-card").then(m => m.StatsCard));
-const RecommendationCard = dynamic(() => import("./recommendation-card").then(m => m.RecommendationCard));
-const ExportImageCard = dynamic(() => import("./export-image-card").then(m => m.ExportImageCard));
-const HistoryCard = dynamic(() => import("./history-card").then(m => m.HistoryCard));
-const EventsCard = dynamic(() => import("./events-card").then(m => m.EventsCard));
-const RecentSongsCard = dynamic(() => import("./recent-songs-card").then(m => m.RecentSongsCard));
-const DeveloperCard = dynamic(() => import("./developer-card").then(m => m.DeveloperCard));
-const AlbumCard = dynamic(() => import("./album-card").then(m => m.AlbumCard));
+// Each dynamic() shares the card's own skeleton as its `loading`. That does
+// two things: (1) gives Next 16's React.lazy a LOCAL Suspense boundary so the
+// suspension doesn't bubble to the fallback-less <Suspense> wrapping
+// DataContent (which rendered null and blanked the sidebar + content), and
+// (2) makes the chunk-load placeholder identical to the data-load placeholder
+// so the transition into real data is seamless.
+const StatsCard = dynamic(() => import("./stats-card").then(m => m.StatsCard), { loading: () => <StatsCardSkeleton /> });
+const RecommendationCard = dynamic(() => import("./recommendation-card").then(m => m.RecommendationCard), { loading: () => <RecommendationCardSkeleton /> });
+const ExportImageCard = dynamic(() => import("./export-image-card").then(m => m.ExportImageCard), { loading: () => <ExportImageCardSkeleton /> });
+const HistoryCard = dynamic(() => import("./history-card").then(m => m.HistoryCard), { loading: () => <HistoryCardSkeleton /> });
+const EventsCard = dynamic(() => import("./events-card").then(m => m.EventsCard), { loading: () => <EventsCardSkeleton /> });
+const RecentSongsCard = dynamic(() => import("./recent-songs-card").then(m => m.RecentSongsCard), { loading: () => <RecentSongsCardSkeleton /> });
+const DeveloperCard = dynamic(() => import("./developer-card").then(m => m.DeveloperCard), { loading: () => <DeveloperCardSkeleton /> });
+const AlbumCard = dynamic(() => import("./album-card").then(m => m.AlbumCard), { loading: () => <AlbumCardSkeleton /> });
 
 interface DataContentProps {
   region: Region;
@@ -62,8 +75,6 @@ export function DataContent({
   flags,
 }: DataContentProps) {
   const t = useTranslations();
-  const router = useRouter();
-  const pathname = usePathname();
   const searchParams = useSearchParams();
   const isDesktop = useMediaQuery("(min-width: 768px)", { initializeWithValue: false });
 
@@ -89,27 +100,26 @@ export function DataContent({
 
   const [selectedTab, setSelectedTab] = useState(getInitialTab);
 
+  // Update the URL via the native History API so Next.js doesn't re-fetch the
+  // RSC payload and re-suspend the <Suspense> boundary that wraps DataContent
+  // (which is what caused the tab+content to flash out on every tab switch).
+  const updateTabUrl = (value: string) => {
+    if (typeof window === "undefined") return;
+    const params = new URLSearchParams(window.location.search);
+    if (value === "songs") {
+      params.delete('tab');
+    } else {
+      params.set('tab', value);
+    }
+    const qs = params.toString();
+    const next = qs ? `${window.location.pathname}?${qs}` : window.location.pathname;
+    window.history.replaceState(null, "", next);
+  };
+
   // Update URL when tab changes
   const handleTabChange = (value: string) => {
     setSelectedTab(value);
-
-    // Create new search params
-    const newSearchParams = new URLSearchParams(searchParams.toString());
-
-    if (value === "songs") {
-      // Remove tab parameter for default tab
-      newSearchParams.delete('tab');
-    } else {
-      // Set tab parameter for non-default tabs
-      newSearchParams.set('tab', value);
-    }
-
-    // Build the URL with or without search params
-    const searchString = newSearchParams.toString();
-    const newUrl = searchString ? `${pathname}?${searchString}` : pathname;
-
-    // Update URL without triggering a full page reload
-    router.replace(newUrl, { scroll: false });
+    updateTabUrl(value);
   };
 
   // Define visible tabs based on privacy settings
@@ -183,13 +193,9 @@ export function DataContent({
   useEffect(() => {
     if (selectedSnapshotData && !validTabs.includes(selectedTab)) {
       setSelectedTab("songs");
-      const newSearchParams = new URLSearchParams(searchParams.toString());
-      newSearchParams.delete('tab'); // Remove tab param when falling back to songs
-      const searchString = newSearchParams.toString();
-      const newUrl = searchString ? `${pathname}?${searchString}` : pathname;
-      router.replace(newUrl, { scroll: false });
+      updateTabUrl("songs");
     }
-  }, [selectedTab, validTabs, pathname, router, searchParams, selectedSnapshotData]);
+  }, [selectedTab, validTabs, selectedSnapshotData]);
 
   if (isLoading) {
     return (

--- a/apps/main/src/components/developer-card.skeleton.tsx
+++ b/apps/main/src/components/developer-card.skeleton.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { Code } from "lucide-react";
+import { Skeleton } from "@tomomai/ui";
+import { useTranslations } from "next-intl";
+
+export function DeveloperCardSkeleton() {
+  const t = useTranslations();
+  return (
+    <div className="w-full mx-auto space-y-6">
+      <h2 className="text-lg font-semibold flex items-center gap-2">
+        <Code className="h-5 w-5" />
+        {t("dataContent.tabs.developer")}
+      </h2>
+      <div className="space-y-4">
+        <Skeleton className="h-10 w-40" />
+        <Skeleton className="h-24 w-full rounded-lg" />
+        <Skeleton className="h-40 w-full rounded-lg" />
+      </div>
+    </div>
+  );
+}

--- a/apps/main/src/components/events-card.skeleton.tsx
+++ b/apps/main/src/components/events-card.skeleton.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { Map } from "lucide-react";
+import { Skeleton } from "@tomomai/ui";
+import { useTranslations } from "next-intl";
+
+export function EventsCardSkeleton() {
+  const t = useTranslations();
+  return (
+    <div className="w-full space-y-6">
+      <h2 className="text-lg font-semibold flex items-center gap-2">
+        <Map className="h-5 w-5" />
+        {t("events.title")}
+      </h2>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="flex gap-3 p-4 border rounded-lg">
+            <Skeleton className="w-16 h-16 rounded shrink-0" />
+            <div className="flex-1 min-w-0 space-y-2">
+              <Skeleton className="h-4 w-3/4" />
+              <Skeleton className="h-3 w-1/2" />
+              <Skeleton className="h-2 w-full" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/main/src/components/export-image-card.skeleton.tsx
+++ b/apps/main/src/components/export-image-card.skeleton.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { Download } from "lucide-react";
+import { Skeleton } from "@tomomai/ui";
+import { useTranslations } from "next-intl";
+
+export function ExportImageCardSkeleton() {
+  const t = useTranslations();
+  return (
+    <div className="w-full mx-auto space-y-6">
+      <h2 className="text-lg font-semibold flex items-center gap-2">
+        <Download className="h-5 w-5" />
+        {t("dataContent.tabs.exportImage")}
+      </h2>
+      <Skeleton className="w-full aspect-[3/4] max-w-md mx-auto rounded-lg" />
+    </div>
+  );
+}

--- a/apps/main/src/components/history-card.skeleton.tsx
+++ b/apps/main/src/components/history-card.skeleton.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { TrendingUp } from "lucide-react";
+import { Skeleton } from "@tomomai/ui";
+import { useTranslations } from "next-intl";
+
+export function HistoryCardSkeleton() {
+  const t = useTranslations();
+  return (
+    <div className="space-y-6">
+      <h2 className="text-lg font-semibold flex items-center gap-2">
+        <TrendingUp className="h-5 w-5" />
+        {t("dataContent.history.title")}
+      </h2>
+      <div className="h-[400px] flex flex-col justify-end gap-2 p-4">
+        <div className="flex-1 flex items-end gap-1">
+          {Array.from({ length: 12 }).map((_, i) => (
+            <Skeleton
+              key={i}
+              className="flex-1 rounded-t"
+              style={{ height: `${30 + ((i * 37) % 60)}%` }}
+            />
+          ))}
+        </div>
+        <Skeleton className="h-4 w-full" />
+      </div>
+    </div>
+  );
+}

--- a/apps/main/src/components/history-card.tsx
+++ b/apps/main/src/components/history-card.tsx
@@ -7,8 +7,8 @@ import { trpc } from "@/lib/trpc-client";
 import { Region } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { TrendingUp } from "lucide-react";
-import { Skeleton } from "@tomomai/ui";
 import { useTranslations } from "next-intl";
+import { HistoryCardSkeleton } from "./history-card.skeleton";
 import { CoverImage } from "@/components/cover-image";
 import { useEffect, useMemo, useState } from "react";
 import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts";
@@ -127,6 +127,10 @@ export function HistoryCard({ region }: HistoryCardProps) {
     };
   }, [chartData]);
 
+  if (isLoading) {
+    return <HistoryCardSkeleton />;
+  }
+
   return (
     <div className="space-y-6">
       <h2 className="text-lg font-semibold flex items-center gap-2">
@@ -134,20 +138,7 @@ export function HistoryCard({ region }: HistoryCardProps) {
         {t("dataContent.history.title")}
       </h2>
       <div>
-        {isLoading ? (
-          <div className="h-[400px] flex flex-col justify-end gap-2 p-4">
-            <div className="flex-1 flex items-end gap-1">
-              {Array.from({ length: 12 }).map((_, i) => (
-                <Skeleton
-                  key={i}
-                  className="flex-1 rounded-t"
-                  style={{ height: `${30 + Math.random() * 60}%` }}
-                />
-              ))}
-            </div>
-            <Skeleton className="h-4 w-full" />
-          </div>
-        ) : chartData.length < 2 ? (
+        {chartData.length < 2 ? (
           <div className="h-[400px] flex flex-col items-center justify-center text-muted-foreground">
             <TrendingUp className="h-12 w-12 mb-4 opacity-50" />
             <h3 className="text-lg font-medium mb-2">{t("dataContent.history.noHistory")}</h3>

--- a/apps/main/src/components/recent-songs-card.skeleton.tsx
+++ b/apps/main/src/components/recent-songs-card.skeleton.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { Clock } from "lucide-react";
+import { Skeleton } from "@tomomai/ui";
+import { useTranslations } from "next-intl";
+
+export function RecentSongsCardSkeleton() {
+  const t = useTranslations("recentPlays");
+  return (
+    <div className="space-y-6">
+      <h2 className="text-lg font-semibold flex items-center gap-2">
+        <Clock className="h-5 w-5" />
+        {t("title")}
+      </h2>
+      <div className="divide-y divide-dashed divide-border">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="flex gap-4 py-4">
+            <Skeleton className="w-14 h-14 rounded shrink-0" />
+            <div className="flex-1 min-w-0 space-y-2">
+              <Skeleton className="h-4 w-3/4" />
+              <Skeleton className="h-3 w-1/2" />
+              <Skeleton className="h-3 w-1/3" />
+            </div>
+            <div className="text-right space-y-2">
+              <Skeleton className="h-4 w-16 ml-auto" />
+              <Skeleton className="h-3 w-12 ml-auto" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/main/src/components/recent-songs-card.tsx
+++ b/apps/main/src/components/recent-songs-card.tsx
@@ -4,8 +4,8 @@ import { trpc } from "@/lib/trpc-client";
 import { Region } from "@/lib/types";
 import { cn, createSafeMaimaiImageUrl, getTypeBadgeUrl } from "@/lib/utils";
 import { Activity, Calendar, ChevronDown, ChevronRight, ChevronUp, Clock, Loader2, AlertCircle, TrendingUp, TrendingDown, Trophy, FastForward, Rewind, ArrowBigUpDash, ArrowBigDownDash, Grip, Sparkle, MapPin, SeparatorVertical, Slash, Star, Music, CloudOff } from "lucide-react";
-import { Skeleton } from "@tomomai/ui";
 import { useTranslations } from "next-intl";
+import { RecentSongsCardSkeleton } from "./recent-songs-card.skeleton";
 
 import { CoverImage } from "@/components/cover-image";
 import { Link } from "@/i18n/navigation"
@@ -614,30 +614,7 @@ export function RecentSongsCard({ region, beforeDate, snapshotId }: RecentSongsC
   const sentinelRef = useInfiniteScroll(loadMore, hasMore && !isFetching);
 
   if (isLoading && offset === 0) {
-    return (
-      <div className="space-y-6">
-        <h2 className="text-lg font-semibold flex items-center gap-2">
-          <Clock className="h-5 w-5" />
-          {t('title')}
-        </h2>
-        <div className="divide-y divide-dashed divide-border">
-          {Array.from({ length: 5 }).map((_, i) => (
-            <div key={i} className="flex gap-4 py-4">
-              <Skeleton className="w-14 h-14 rounded shrink-0" />
-              <div className="flex-1 min-w-0 space-y-2">
-                <Skeleton className="h-4 w-3/4" />
-                <Skeleton className="h-3 w-1/2" />
-                <Skeleton className="h-3 w-1/3" />
-              </div>
-              <div className="text-right space-y-2">
-                <Skeleton className="h-4 w-16 ml-auto" />
-                <Skeleton className="h-3 w-12 ml-auto" />
-              </div>
-            </div>
-          ))}
-        </div>
-      </div>
-    );
+    return <RecentSongsCardSkeleton />;
   }
 
   if (error) {

--- a/apps/main/src/components/recommendation-card.skeleton.tsx
+++ b/apps/main/src/components/recommendation-card.skeleton.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { Heart } from "lucide-react";
+import { Skeleton } from "@tomomai/ui";
+import { useTranslations } from "next-intl";
+
+export function RecommendationCardSkeleton() {
+  const t = useTranslations();
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-lg font-semibold flex items-center gap-2">
+          <Heart className="h-5 w-5 text-pink-500" />
+          {t("dataContent.tabs.recommendations")}
+        </h2>
+        <div className="text-sm text-muted-foreground">
+          {t("recommendations.description")}
+        </div>
+      </div>
+      <div className="space-y-1">
+        {Array.from({ length: 8 }).map((_, i) => (
+          <div key={i} className="flex items-center h-16 px-2 -mx-2 rounded-md">
+            <Skeleton className="w-8 h-8 ml-1 mr-3 rounded shrink-0" />
+            <div className="flex-1 min-w-0 space-y-2">
+              <Skeleton className="h-4 w-1/2" />
+              <Skeleton className="h-3 w-2/3" />
+            </div>
+            <div className="text-right space-y-2 ml-2">
+              <Skeleton className="h-4 w-20" />
+              <Skeleton className="h-3 w-16 ml-auto" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/main/src/components/stats-card.skeleton.tsx
+++ b/apps/main/src/components/stats-card.skeleton.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { Skeleton } from "@tomomai/ui";
+import { useTranslations } from "next-intl";
+
+export function StatsCardSkeleton() {
+  const t = useTranslations();
+  return (
+    <div className="space-y-6">
+      <h2 className="text-lg font-semibold">{t("playerStats.title")}</h2>
+      <div>
+        <div className="flex flex-col sm:flex-row gap-2">
+          <Skeleton className="h-10 w-full sm:w-[200px]" />
+          <Skeleton className="h-10 w-full sm:w-[200px]" />
+          <div className="flex-1" />
+          <Skeleton className="h-8 w-full sm:w-40" />
+        </div>
+      </div>
+      <div className="space-y-4">
+        <Skeleton className="h-4 w-32" />
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div key={i} className="space-y-2">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <Skeleton className="w-12 h-6 rounded" />
+                <Skeleton className="h-4 w-24" />
+              </div>
+              <Skeleton className="h-4 w-12" />
+            </div>
+            <Skeleton className="h-2 w-full" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/main/src/components/stats-card.tsx
+++ b/apps/main/src/components/stats-card.tsx
@@ -9,7 +9,7 @@ import { getVersionInfo, VERSIONS } from "@/lib/metadata";
 import { Region, SnapshotWithSongs } from "@/lib/types";
 import { trpc } from "@/lib/trpc-client";
 import { ArrowLeft, Award, ChevronRight, Loader2 } from "lucide-react";
-import { Skeleton } from "@tomomai/ui";
+import { StatsCardSkeleton } from "./stats-card.skeleton";
 import { useTranslations } from "next-intl";
 import { useMemo, useState } from "react";
 import { motion, AnimatePresence } from "motion/react";
@@ -449,34 +449,7 @@ export function StatsCard({ region, selectedSnapshotData, snapshotId }: StatsCar
   }, [filteredStats.grades]);
 
   if (isLoading) {
-    return (
-      <div className="space-y-6">
-        <div>
-          <Skeleton className="h-6 w-40 mb-4" />
-          <div className="flex flex-col sm:flex-row gap-2">
-            <Skeleton className="h-10 w-full sm:w-[200px]" />
-            <Skeleton className="h-10 w-full sm:w-[200px]" />
-            <div className="flex-1" />
-            <Skeleton className="h-8 w-full sm:w-40" />
-          </div>
-        </div>
-        <div className="space-y-4">
-          <Skeleton className="h-4 w-32" />
-          {Array.from({ length: 6 }).map((_, i) => (
-            <div key={i} className="space-y-2">
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-2">
-                  <Skeleton className="w-12 h-6 rounded" />
-                  <Skeleton className="h-4 w-24" />
-                </div>
-                <Skeleton className="h-4 w-12" />
-              </div>
-              <Skeleton className="h-2 w-full" />
-            </div>
-          ))}
-        </div>
-      </div>
-    );
+    return <StatsCardSkeleton />;
   }
 
   if (!data || Object.keys(data.stats).length === 0) {


### PR DESCRIPTION
Two independent fixes for the `/profile/[username]` flow that surfaced after the ISR work in #44/#45/#48.

## 1. Tab content disappears for ~0.5s when switching tabs

**Cause:** PR #45 wrapped `<DataContent>` in a fallback-less `<Suspense>` to keep `/profile/[username]/[region]` ISR (so `useSearchParams()` wouldn't bail out of static rendering). That exposed a *second* suspender: every lazy tab card was a bare `next/dynamic()` with no `loading`. In Next 16, that means `React.lazy` has **no local Suspense boundary**, so the chunk-load suspension bubbles to the outer fallback-less `<Suspense>` — which renders `null`. Result: on first visit to each tab, the sidebar tabs **and** the card content vanish for ~half a second until the chunk resolves.

**Fix:** give each `dynamic()` a `loading` so Next wraps it in a **local** Suspense boundary. Each fallback reuses a dedicated `<card>.skeleton.tsx` — a single source of truth (cards that previously had an inline `isLoading` skeleton now import the same component), so the chunk-load placeholder is byte-identical to the data-load placeholder and the transition into real data is seamless (no spinner → skeleton → data jump).

Also: `handleTabChange` now updates the URL via `window.history.replaceState` instead of `router.replace`, so switching tabs no longer refetches the RSC payload (a separate source of churn under the Suspense boundary).

## 2. Static-render bailout on `/profile/[username]`

`Page changed from static to dynamic at runtime, reason: headers` logged on every visit to the redirect route.

**Cause:** next-intl's `requestLocale` falls back to reading `Accept-Language` from `headers()` when `setRequestLocale()` hasn't populated the per-request cache in the current scope. The profile pages relied only on `[locale]/layout.tsx`'s `setStaticLocale()` call, which covers the page render but **not** `generateMetadata`'s separate scope → `generateMetadata`'s `getLocale()` negotiated from headers and bailed out of static rendering.

- The **redirect route** (`/profile/[username]`) hit this *every request* because its redirect target comes from a DB lookup, so it can never be ISR-cached. PR #44's caching intent lives on the **region route**, which stays ISR — the redirect route returns no HTML (it just redirects) and had nothing cacheable.
- The **region route** (`/profile/[username]/[region]`) had the same latent bug but hid it behind ISR caching (`revalidate: 300`).

**Fix:**
- Call `setStaticLocale(routeLocale)` in both `generateMetadata` and the page of both profile routes, matching the existing `db/posts` pattern. This makes the region route cache cleanly.
- Declare the redirect route `force-dynamic` — it's request-time by nature (per-user redirect target), so ISR generation was only ever producing bailout errors.

## Files
- `apps/main/src/components/data-content.tsx` — local Suspense per card via `loading`; `replaceState` URL updates
- `apps/main/src/components/*-card.skeleton.tsx` — 8 new per-card skeleton modules (single source of truth)
- `apps/main/src/components/{stats,recent-songs,album,history}-card.tsx` — import the shared skeleton, drop inline `isLoading` JSX
- `apps/main/src/app/[locale]/profile/[username]/page.tsx` — `force-dynamic` + locale pin
- `apps/main/src/app/[locale]/profile/[username]/[region]/page.tsx` — locale pin (stays ISR)

## Verification
- `tsc --noEmit`: clean for all touched files
- `eslint`: no new errors/warnings (remaining are pre-existing `react-hooks/refs` / `setState-in-effect`)
- Manual: `pnpm build && pnpm start` — tab switching no longer blanks, headers bailout no longer logged on the redirect route

Follow-up (out of scope): a couple of other `generateMetadata` pages call `getLocale()`/`getTranslations()` without pinning the locale; worth a separate pass if the pattern is widespread.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added polished loading placeholders for multiple profile dashboard sections, including stats, recommendations, albums, recent songs, history, events, developer info, and export image.
  * Improved the profile experience with localized loading states and translated section headings.
* **Bug Fixes**
  * Profile pages now consistently apply the selected language before rendering metadata, links, and page content.
  * The main profile route now updates immediately at request time, helping ensure users see the latest profile and correct regional redirect behavior.
* **Refactor**
  * Simplified tab navigation updates and made loading states more modular and consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->