### PR TITLE
fix(i18n/guess): add cookie pathMode for locale switching

### DIFF
--- a/apps/guess/src/app/layout.tsx
+++ b/apps/guess/src/app/layout.tsx
@@ -87,7 +87,7 @@ export default async function RootLayout({
         className={`${inter.variable} ${geistMono.variable} ${murecho.variable} ${notoSansJP.variable} ${notoSansSC.variable} ${notoSansTC.variable} antialiased bg-background min-h-dvh`}
       >
         <NextIntlClientProvider messages={messages}>
-          <LocaleProvider initialLocale={locale}>
+          <LocaleProvider initialLocale={locale} pathMode="cookie">
             <ThemeProvider>
               {children}
               <Toaster />

--- a/packages/i18n/src/client.tsx
+++ b/packages/i18n/src/client.tsx
@@ -43,9 +43,20 @@ export function stripLocaleFromPath(pathname: string): string {
 interface LocaleContextType {
   locale: Locale;
   setLocale: (locale: Locale) => void;
+  pathMode: LocalePathMode;
 }
 
 const LocaleContext = createContext<LocaleContextType | undefined>(undefined);
+
+/**
+ * How `setLocale` updates the URL.
+ * - `'segment'` (default): rewrite the leading `/{locale}` segment. For apps
+ *   using `[locale]/...` routing (apps/main), where locale lives in the URL.
+ * - `'cookie'`: set the cookie and reload the current path as-is. For apps
+ *   that detect locale from the cookie server-side and have no locale
+ *   segment (apps/guess); rewriting the path would 404 there.
+ */
+export type LocalePathMode = 'segment' | 'cookie';
 
 interface LocaleProviderProps {
   children: React.ReactNode;
@@ -56,29 +67,42 @@ interface LocaleProviderProps {
    * a single locale regardless of user choice.
    */
   forcedLocale?: Locale;
+  /**
+   * Controls how `setLocale` navigates. Defaults to `'segment'`.
+   */
+  pathMode?: LocalePathMode;
 }
 
 export function LocaleProvider({
   children,
   initialLocale,
   forcedLocale,
+  pathMode = 'segment',
 }: LocaleProviderProps) {
   const [locale, setLocaleState] = useState<Locale>(forcedLocale ?? initialLocale);
   const router = useRouter();
   const pathname = usePathname();
 
+  // In cookie mode the URL never carries the locale, so there's nothing to
+  // sync from the pathname.
   useEffect(() => {
-    if (forcedLocale) return;
+    if (forcedLocale || pathMode === 'cookie') return;
     const first = pathname.split("/")[1];
     if (first && (locales as readonly string[]).includes(first) && first !== locale) {
       setLocaleState(first as Locale);
     }
-  }, [pathname, locale, forcedLocale]);
+  }, [pathname, locale, forcedLocale, pathMode]);
 
   const setLocale = (newLocale: Locale) => {
     if (forcedLocale) return;
     setLocaleState(newLocale);
     setLocaleCookie(newLocale);
+    if (pathMode === 'cookie') {
+      // No locale segment in the URL — a full reload re-runs server-side
+      // locale detection with the new cookie.
+      if (typeof window !== 'undefined') window.location.reload();
+      return;
+    }
     const next = swapLocaleInPath(pathname || "/", newLocale);
     const search = typeof window !== "undefined" ? window.location.search : "";
     const hash = typeof window !== "undefined" ? window.location.hash : "";
@@ -86,8 +110,8 @@ export function LocaleProvider({
   };
 
   const value = forcedLocale
-    ? { locale: forcedLocale, setLocale: () => {} }
-    : { locale, setLocale };
+    ? { locale: forcedLocale, setLocale: () => {}, pathMode }
+    : { locale, setLocale, pathMode };
 
   return <LocaleContext.Provider value={value}>{children}</LocaleContext.Provider>;
 }
@@ -100,6 +124,11 @@ export function useLocale(): LocaleContextType {
   return context;
 }
 
+/** Convenience hook for just the path mode (used by LocaleSwitcher). */
+export function useLocalePathMode(): LocalePathMode {
+  return useLocale().pathMode;
+}
+
 interface LocaleSwitcherProps {
   forceVisible?: boolean;
 }
@@ -109,6 +138,7 @@ export function LocaleSwitcher({ forceVisible }: LocaleSwitcherProps) {
   const LANGUAGES = getLanguages(t);
   const { locale, setLocale } = useLocale();
   const pathname = usePathname();
+  const pathMode = useLocalePathMode();
 
   const handleNewLocale = (value: string) => {
     const newLocale = value === "auto" ? null : (value as Locale);
@@ -118,6 +148,12 @@ export function LocaleSwitcher({ forceVisible }: LocaleSwitcherProps) {
     } else {
       if (typeof document !== "undefined") {
         document.cookie = "NEXT_LOCALE=; path=/; max-age=0";
+        // In cookie mode the URL has no locale segment — just reload so the
+        // server re-detects from headers.
+        if (pathMode === 'cookie') {
+          window.location.reload();
+          return;
+        }
         const bare = stripLocaleFromPath(pathname || "/");
         window.location.href = bare;
       }


### PR DESCRIPTION
## Why

`apps/guess` reuses the shared `LocaleSwitcher` / `LocaleProvider` from `@tomomai/i18n`, which (after #44) assumes `[locale]`-segment routing: picking a locale rewrites `/2026-06-26` → `/en/2026-06-26` and **404s**, because guess has no `[locale]` segment.

The locale selector was routing users to dead paths.

## Why not port `[locale]` routing to guess

Guess doesn't benefit from segment routing:

- 2 routes (`/`, `/[date]`), both already dynamic because locale is read from the `NEXT_LOCALE` cookie.
- No SEO/catalog subtree to de-dynamicize — that was the whole motivation behind #44.
- OG images, sitemap, and shared links all use bare paths today.

So the fix is to make the shared switcher work in a cookie-only mode and have guess opt in, rather than adding a `[locale]` segment.

## What changed

Added a `pathMode` option to the shared `LocaleProvider` (`packages/i18n/src/client.tsx`):

| Mode | Behavior | Used by |
|---|---|---|
| `'segment'` (default, unchanged) | Rewrite the leading `/{locale}` segment | `apps/main` |
| `'cookie'` (new) | Set the cookie and `window.location.reload()` the current path so the server re-detects locale | `apps/guess` |

Also guards the switcher's **auto** branch: in cookie mode it reloads instead of stripping the (nonexistent) locale segment and hard-navigating to a bare path.

Net diff: 2 files, +41/−5. No new routes; guess stays fully dynamic and cookie-driven.

## Verification

- `apps/guess` `tsc --noEmit` clean
- `apps/main` typecheck clean (default `pathMode` is `'segment'` — no behavior change)
- Manual: locale switching in guess now reloads the current path with the new locale instead of 404ing on `/en/...`

## BREAKING CHANGE

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for cookie-based locale handling alongside URL segment-based locale handling.
  * Locale switching now preserves the current page more reliably, including search and hash values.

* **Bug Fixes**
  * Improved locale synchronization so cookie mode no longer depends on the URL path.
  * Switching back to automatic locale selection now refreshes the page correctly in cookie mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->