### PR TITLE
perf(main/db): cut song-slug ISR cost ~10x via layout-persistent list

### DIFF
--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -31,13 +31,11 @@
     "token:cli": "node scripts/token-cli.js",
     "scripts:validate-snapshot": "node scripts/verify-snapshot.js",
     "scripts:verify-backfill": "node scripts/verify-backfill.js",
-    "scripts:migrate-icons": "node scripts/migrate-icons-to-r2.js"
+    "scripts:migrate-icons": "node scripts/migrate-icons-to-r2.js",
+    "scripts:measure-isr": "node scripts/measure-isr-payload.js --dir .next",
+    "scripts:measure-isr:live": "node scripts/measure-isr-live.js"
   },
   "dependencies": {
-    "@tomomai/ui": "workspace:*",
-    "@tomomai/i18n": "workspace:*",
-    "@tomomai/utils": "workspace:*",
-    "@tomomai/security": "workspace:*",
     "@aws-sdk/client-s3": "^3.990.0",
     "@better-auth/api-key": "^1.6.11",
     "@better-auth/oauth-provider": "^1.6.11",
@@ -63,6 +61,10 @@
     "@radix-ui/react-visually-hidden": "^1.2.4",
     "@tanstack/react-query": "^5.90.21",
     "@tanstack/react-query-devtools": "^5.91.3",
+    "@tomomai/i18n": "workspace:*",
+    "@tomomai/security": "workspace:*",
+    "@tomomai/ui": "workspace:*",
+    "@tomomai/utils": "workspace:*",
     "@trpc/client": "^11.10.0",
     "@trpc/next": "^11.10.0",
     "@trpc/react-query": "^11.10.0",

--- a/apps/main/scripts/measure-isr-live.js
+++ b/apps/main/scripts/measure-isr-live.js
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+// Measures live ISR payload size + cache state for a list of song-slug URLs.
+//
+// `next build` does NOT prerender on-demand ISR routes (generateStaticParams
+// returns []), so the .next/server/app files won't include /db/songs/[slug].
+// To see the real per-slug payload Vercel persists on revalidation, hit the
+// live URLs twice with a 1-second gap: the first request is MISS / REVALIDATED
+// (forces a regeneration → this is what Vercel bills as an ISR write), the
+// second is HIT (cached read, no write). The Content-Length + cache header
+// tell us the payload size and write state.
+//
+// Usage:
+//   node scripts/measure-isr-live.js https://your-deploy.url \
+//     --slugs "_-x0o0x-dx" "coconut" "shigure" [--locale en,ja]
+//
+//   --slugs <a> <b> ...    Song slugs to probe (URL-encoded automatically).
+//   --locale <a,b>         Locales to probe (default: en only).
+//   --base <url>           Production / preview base URL.
+//   --wait <ms>            Gap between MISS and HIT probes (default 1500).
+//   --warm                 Skip the warm-up HIT; go straight to MISS+HIT.
+//
+// Requires a deployed app (localhost won't show real x-nextjs-cache headers
+// unless you `pnpm start` after `pnpm build`).
+
+const argv = process.argv.slice(2);
+const flag = (name, fallback) => {
+  const i = argv.indexOf(name);
+  return i >= 0 ? argv[i + 1] : fallback;
+};
+const arr = (name, fallback) => {
+  const i = argv.indexOf(name);
+  if (i < 0) return fallback;
+  const out = [];
+  for (let j = i + 1; j < argv.length && !argv[j].startsWith("--"); j++) out.push(argv[j]);
+  return out.length ? out : fallback;
+};
+
+const BASE = flag("--base", argv[0] && !argv[0].startsWith("--") ? argv[0] : "").replace(/\/$/, "");
+const SLUGS = arr("--slugs", []);
+// Support `--locale en,ja,zh-TW` (comma-joined) and `--locale en ja zh-TW` (space).
+const LOCALES = arr("--locale", ["en"]).flatMap((s) => s.split(",")).map((s) => s.trim()).filter(Boolean);
+const WAIT_MS = Number(flag("--wait", "1500"));
+
+if (!BASE || SLUGS.length === 0) {
+  console.error("Usage: node scripts/measure-isr-live.js <base-url> --slugs <slug...> [--locale en,ja]");
+  process.exit(1);
+}
+
+const KB = 1024;
+const WRITE_UNIT = 8 * 1024;
+const fmt = (b) => (b >= KB * KB ? `${(b / (KB * KB)).toFixed(2)} MB` : `${(b / KB).toFixed(1)} KB`);
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function probe(url) {
+  const start = Date.now();
+  const res = await fetch(url, { redirect: "manual" });
+  const buf = Buffer.from(await res.arrayBuffer());
+  return {
+    status: res.status,
+    cache: res.headers.get("x-nextjs-cache"),
+    cacheControl: res.headers.get("cache-control"),
+    age: res.headers.get("age"),
+    contentLength: Number(res.headers.get("content-length") ?? buf.length),
+    bytes: buf.length,
+    ms: Date.now() - start,
+  };
+}
+
+function summarize(url, miss, hit) {
+  const units = Math.ceil(miss.bytes / WRITE_UNIT);
+  console.log(
+    `  ${fmt(miss.bytes).padStart(10)}  ${String(units).padStart(4)}u  ` +
+      `miss=[${miss.status} ${miss.cache ?? "-"} ${miss.ms}ms] ` +
+      `hit=[${hit.status} ${hit.cache ?? "-"} ${hit.ms}ms]  ${url}`,
+  );
+  return units;
+}
+
+console.log(`Base: ${BASE}`);
+console.log(`Slugs: ${SLUGS.join(", ")} × locales ${LOCALES.join(", ")}\n`);
+
+let totalUnits = 0;
+let totalBytes = 0;
+const revalidated = [];
+
+for (const locale of LOCALES) {
+  console.log(`\u001b[1mlocale=${locale}\u001b[0m`);
+  for (const slug of SLUGS) {
+    const url = `${BASE}/${locale}/db/songs/${encodeURIComponent(slug)}`;
+    // Warm pass first so we always measure a consistent MISS+HIT pair.
+    await probe(url);
+    await sleep(WAIT_MS);
+    // First measured probe: typically MISS (regenerate) or REVALIDATED.
+    const miss = await probe(url);
+    await sleep(WAIT_MS);
+    // Second probe: should be HIT.
+    const hit = await probe(url);
+    const units = summarize(url, miss, hit);
+    totalUnits += units;
+    totalBytes += miss.bytes;
+    if (miss.cache === "REVALIDATED" || miss.cache === "MISS") revalidated.push(url);
+  }
+}
+
+console.log("");
+console.log(`\u001b[1mTotal across ${SLUGS.length * LOCALES.length} slugs:\u001b[0m ${fmt(totalBytes)}, ${totalUnits} ISR write units`);
+console.log(`Cost per revalidation cycle at $0.40 / 100k units: $${((totalUnits / 100_000) * 0.4).toFixed(4)}`);
+if (revalidated.length) {
+  console.log(`\u001b[33m${revalidated.length} URL(s) returned REVALIDATED/MISS → these are the routes Vercel bills as ISR writes.\u001b[0m`);
+} else {
+  console.log(`No URL returned REVALIDATED/MISS — increase --wait or check the deploy.`);
+}

--- a/apps/main/scripts/measure-isr-payload.js
+++ b/apps/main/scripts/measure-isr-payload.js
@@ -1,0 +1,207 @@
+#!/usr/bin/env node
+// Measures the on-disk ISR payload size for every prerendered /db/songs/[slug]
+// route and estimates Vercel ISR write units (ceil(payload_bytes / 8KB)).
+//
+// Vercel bills ISR writes as the prerendered page artifact size rounded up to
+// the nearest 8KB unit, charged every time the route is regenerated. By
+// inspecting what `next build` writes under .next/server/app, we see the same
+// payload bytes Vercel persists on each revalidation — so the per-route
+// numbers below are exactly the cost lever we can pull.
+//
+// Usage:
+//   pnpm --filter @tomomai/site build           # build first
+//   node scripts/measure-isr-payload.js [--dir .next] [--top 30] [--by-locale]
+//
+// Notes:
+// - Counts .html + .rsc + .meta for every prerendered route. The HTML and
+//   RSC flight data are what Vercel stores on a revalidation; the .meta is
+//   small but included for completeness.
+// - og-image / sitemap / robots / api are excluded (they are not billed as
+//   ISR page writes for the [slug] route).
+
+import fs from "node:fs";
+import path from "node:path";
+
+const argv = process.argv.slice(2);
+const getFlag = (name, fallback) => {
+  const i = argv.indexOf(name);
+  return i >= 0 ? argv[i + 1] : fallback;
+};
+const NEXT_DIR = getFlag("--dir", ".next");
+const TOP = Number(getFlag("--top", "30"));
+const BY_LOCALE = argv.includes("--by-locale");
+
+const appDir = path.join(NEXT_DIR, "server", "app");
+if (!fs.existsSync(appDir)) {
+  console.error(`No .next build found at ${appDir}. Run \`pnpm --filter @tomomai/site build\` first.`);
+  process.exit(1);
+}
+
+const KB = 1024;
+const WRITE_UNIT = 8 * 1024; // Vercel: 1 ISR write unit = 8KB
+
+const fmt = (bytes) => {
+  if (bytes >= KB * KB) return `${(bytes / (KB * KB)).toFixed(2)} MB`;
+  return `${(bytes / KB).toFixed(1)} KB`;
+};
+
+// Recursively collect (file, size) pairs.
+function walk(dir, out = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(full, out);
+    else out.push(full);
+  }
+  return out;
+}
+
+const files = walk(appDir);
+
+// Next stores prerendered routes as <route-path>.html, <route-path>.rsc, etc.
+// A single logical route = the set of files sharing a base path under its
+// page directory. We group by the file's directory + basename-without-ext
+// (e.g. ".../db/[type]/[slug]/<slug-value>.html" and ".rsc" share a base).
+const buckets = new Map(); // base -> { dir, base, exts: {html, rsc, meta, ...} }
+for (const f of files) {
+  const ext = path.extname(f); // .html, .rsc, .meta, .json, ...
+  if (!["html", "rsc", "meta", "json"].includes(ext.slice(1))) continue;
+  const dir = path.dirname(f);
+  const base = path.basename(f, ext);
+  const key = `${dir}::${base}`;
+  if (!buckets.has(key)) buckets.set(key, { dir, base, exts: {} });
+  buckets.get(key).exts[ext.slice(1)] = fs.statSync(f).size;
+}
+
+// Build per-route rows. A route is "interesting" if its path looks like a
+// /db/songs/[slug] page (server app dir layout: .../db/[type]/[slug]/... or
+// .../db/... ). We label each row with a human path.
+const rows = [];
+for (const { dir, base, exts } of buckets.values()) {
+  // Skip the canonical "[type]" / "[slug]" template dirs — we want the
+  // prerendered instances (real slug values, no brackets).
+  const rel = path.relative(appDir, dir);
+  if (rel.includes("[") || base.includes("[")) continue;
+  const html = exts.html ?? 0;
+  const rsc = exts.rsc ?? 0;
+  const meta = exts.meta ?? 0;
+  const other = Object.entries(exts)
+    .filter(([k]) => !["html", "rsc", "meta"].includes(k))
+    .reduce((s, [, v]) => s + v, 0);
+  const total = html + rsc + meta + other;
+  if (total === 0) continue;
+  rows.push({
+    route: rel ? `${rel}/${base}` : base,
+    html, rsc, meta, other, total,
+    units: Math.ceil(total / WRITE_UNIT),
+  });
+}
+
+// Focus: /db/songs/[slug]. After the i18n [locale] segment, the server dir
+// layout is roughly:
+//   [locale]/db/[type]/[slug]/<encoded-slug>.html
+// The first path part is the locale; the rest mirrors the URL.
+const songRows = rows.filter((r) => /^([a-z-]+)\/db\/songs\/[^/]+$/.test(r.route));
+
+function banner(label) {
+  console.log("");
+  console.log(`\u001b[1m\u001b[36m${label}\u001b[0m`);
+}
+
+function summarize(label, list) {
+  if (list.length === 0) {
+    console.log(`  (no routes matched)`);
+    return;
+  }
+  const totals = list.reduce(
+    (a, r) => {
+      a.html += r.html; a.rsc += r.rsc; a.total += r.total; a.units += r.units;
+      return a;
+    },
+    { html: 0, rsc: 0, total: 0, units: 0 },
+  );
+  const count = list.length;
+  const avg = totals.total / count;
+  console.log(
+    `  ${label}: ${count} routes, total ${fmt(totals.total)}, avg ${fmt(avg)}, ` +
+      `avg units/route ${(totals.units / count).toFixed(1)}, total units ${totals.units.toLocaleString()}`,
+  );
+}
+
+// Report the per-route RSC segments Next emits alongside the page RSC. These
+// are the segment blobs Vercel persists and re-persists on ISR revalidation;
+// the biggest ones (e.g. [type]/layout SongsList segment) are the levers.
+function segmentReport() {
+  const segDirs = new Set();
+  for (const f of files) {
+    if (f.endsWith(".segments") || f.includes(".segments/")) {
+      const segRoot = f.split(".segments")[0] + ".segments";
+      segDirs.add(segRoot);
+    }
+  }
+  const rows = [];
+  for (const dir of segDirs) {
+    if (!fs.existsSync(dir)) continue;
+    let total = 0;
+    const files2 = walk(dir);
+    for (const f of files2) total += fs.statSync(f).size;
+    const rel = path.relative(appDir, dir);
+    rows.push({ rel, total, units: Math.ceil(total / WRITE_UNIT) });
+  }
+  rows.sort((a, b) => b.total - a.total);
+  console.log("");
+  console.log(`\u001b[1m\u001b[36mTop ${TOP} largest shared RSC segments (also billed on revalidation)\u001b[0m`);
+  for (const r of rows.slice(0, TOP)) {
+    console.log(`  ${fmt(r.total).padStart(11)}  ${String(r.units).padStart(4)}u  ${r.rel}`);
+  }
+}
+
+banner("Overview");
+summarize("All prerendered routes", rows);
+summarize("/db/songs/[slug] (all locales)", songRows);
+
+if (BY_LOCALE) {
+  const byLocale = new Map();
+  for (const r of songRows) {
+    const locale = r.route.split("/")[0];
+    if (!byLocale.has(locale)) byLocale.set(locale, []);
+    byLocale.get(locale).push(r);
+  }
+  banner("/db/songs/[slug] by locale");
+  for (const [locale, list] of [...byLocale.entries()].sort()) {
+    summarize(`locale=${locale}`, list);
+  }
+}
+
+segmentReport();
+
+banner(`Top ${TOP} largest /db/songs/[slug] routes (by payload size)`);
+const sorted = [...songRows].sort((a, b) => b.total - a.total).slice(0, TOP);
+for (const r of sorted) {
+  console.log(
+    `  ${fmt(r.total).padStart(11)}  ${String(r.units).padStart(4)}u  ` +
+      `html=${fmt(r.html).padStart(8)} rsc=${fmt(r.rsc).padStart(8)}  ${r.route}`,
+  );
+}
+
+banner(`Top ${TOP} smallest (sanity check — should not be tiny)`);
+const smallest = [...songRows].sort((a, b) => a.total - b.total).slice(0, Math.min(5, TOP));
+for (const r of smallest) {
+  console.log(
+    `  ${fmt(r.total).padStart(11)}  ${String(r.units).padStart(4)}u  ${r.route}`,
+  );
+}
+
+// Cost model: assume a regeneration cadence and report projected units/day.
+banner("Cost projection (daily revalidation of every song slug, all locales)");
+const perDay = songRows.length; // 1-day revalidate on /db/songs/[slug] → ~1 regen/day per route
+const unitsPerDay = songRows.reduce((s, r) => s + r.units, 0);
+const dollarsPerDayAt40cPer1k = (unitsPerDay / 1_000_000) * 1000 * 0.4; // $0.40 per 100k → $4 / 1M
+console.log(
+  `  Routes regenerating: ${perDay.toLocaleString()}/day (assuming revalidate=86400, 1 hit per stale route)`,
+);
+console.log(`  Units/day if each route regenerates once: ${unitsPerDay.toLocaleString()}`);
+console.log(`  Projected cost/day at $0.40 per 100k units:  $${dollarsPerDayAt40cPer1k.toFixed(2)}`);
+console.log(
+  `  If each route regenerates N times/day, multiply by N. On-demand ISR regenerates ` +
+    `on every request that lands after the page goes stale — popular slugs may regen many times.`,
+);

--- a/apps/main/src/app/[locale]/db/@detail/[type]/[slug]/page.tsx
+++ b/apps/main/src/app/[locale]/db/@detail/[type]/[slug]/page.tsx
@@ -4,7 +4,7 @@ import { safeDecodeURIComponent } from "@/lib/utils";
 import { getTranslations } from "next-intl/server";
 
 // Match the parent [slug] route's ISR mode.
-export const revalidate = 86400;
+export const revalidate = 1209600;
 
 export async function headers() {
   return {

--- a/apps/main/src/app/[locale]/db/[type]/[slug]/page.tsx
+++ b/apps/main/src/app/[locale]/db/[type]/[slug]/page.tsx
@@ -1,14 +1,15 @@
+import { InlineNotFound } from "@/components/inline-not-found";
 import { getAllUniqueSongsCached } from "@/server/queries/songs-cache";
 import { Metadata } from "next";
-import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 import { getLocale } from "@/i18n/locale-server";
 import { buildAlternates, breadcrumbJsonLd, openGraphLocales, ogImageUrl, localizePath } from "@/lib/seo";
 import { resolveBaseUrl } from "@/lib/base-url";
 import { safeDecodeURIComponent } from "@/lib/utils";
 
-// On-demand ISR.
-export const revalidate = 86400;
+// On-demand ISR. Catalog edits are pushed live by /api/admin/upload via
+// revalidatePath per affected slug; 14d is the fallback freshness window.
+export const revalidate = 1209600;
 
 export async function headers() {
   return {
@@ -35,74 +36,82 @@ export async function generateMetadata({ params }: DbSlugPageProps): Promise<Met
   }
 
   const decodedSlug = safeDecodeURIComponent(slug);
-  const [songs, t, locale] = await Promise.all([
-    getAllUniqueSongsCached(),
+  const songs = await getAllUniqueSongsCached();
+  const song = songs.find(s => s.slug === decodedSlug);
+  const path = `/db/songs/${encodeURIComponent(decodedSlug)}`;
+
+  // Resolve locale/translations only when the song exists. For unknown slugs
+  // bail with minimal metadata — this also keeps the invalid-slug path off
+  // the locale-resolution code that would otherwise read headers.
+  if (!song) {
+    return {
+      title: "Song not found | tomomai ともマイ",
+      robots: { index: false, follow: false },
+      alternates: {},
+    };
+  }
+
+  const [t, locale] = await Promise.all([
     getTranslations("db.songs.metadata"),
     getLocale(),
   ]);
 
-  const song = songs.find(s => s.slug === decodedSlug);
-  const path = `/db/songs/${encodeURIComponent(decodedSlug)}`;
-
-  if (song) {
-    const chartType = song.type === "dx" ? t("chartTypeDx") : t("chartTypeStandard");
-    const title = t("songTitle", { songName: song.songName, artist: song.artist });
-    const description = t("songDescription", {
-      songName: song.songName,
-      artist: song.artist,
-      chartType,
-      genre: song.genre,
-    });
-    const ogDescription = t("songOgDescription", {
-      songName: song.songName,
-      artist: song.artist,
-    });
-
-    return {
-      title,
-      description,
-      alternates: await buildAlternates(path),
-      openGraph: {
-        title,
-        description: ogDescription,
-        url: localizePath(path, locale),
-        siteName: "tomomai ともマイ",
-        type: "article",
-        images: [{ url: ogImageUrl(path, locale) }],
-        ...openGraphLocales(locale),
-      },
-      twitter: {
-        card: "summary_large_image",
-        title,
-        description: ogDescription,
-      },
-    };
-  }
+  const chartType = song.type === "dx" ? t("chartTypeDx") : t("chartTypeStandard");
+  const title = t("songTitle", { songName: song.songName, artist: song.artist });
+  const description = t("songDescription", {
+    songName: song.songName,
+    artist: song.artist,
+    chartType,
+    genre: song.genre,
+  });
+  const ogDescription = t("songOgDescription", {
+    songName: song.songName,
+    artist: song.artist,
+  });
 
   return {
-    title: t("songFallbackTitle"),
-    description: t("songFallbackDescription"),
+    title,
+    description,
     alternates: await buildAlternates(path),
+    openGraph: {
+      title,
+      description: ogDescription,
+      url: localizePath(path, locale),
+      siteName: "tomomai ともマイ",
+      type: "article",
+      images: [{ url: ogImageUrl(path, locale) }],
+      ...openGraphLocales(locale),
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description: ogDescription,
+    },
   };
 }
 
 export default async function DbSlugPage({ params }: DbSlugPageProps) {
   const { type, slug } = await params;
 
-  if (type !== "songs") {
-    notFound();
-  }
-
-  // The list is mounted by /db/[type]/layout.tsx; the song detail content
-  // is rendered by the @detail parallel slot at /db/@detail/[type]/[slug].
-  // This page just emits per-song JSON-LD.
+  // Non-songs types have no detail page — render the inline not-found UI
+  // (see note on InlineNotFound below).
+  // The song-detail content is rendered by the @detail parallel slot at
+  // /db/@detail/[type]/[slug]. This page renders the songs list (hydrated
+  // client-side behind the drawer — no `initialSongs` prop, so the catalog
+  // isn't serialized into the ISR payload) plus per-song JSON-LD.
 
   const decodedSlug = safeDecodeURIComponent(slug);
   const songs = await getAllUniqueSongsCached();
-  const song = songs.find(s => s.slug === decodedSlug);
+  const song = type === "songs" ? songs.find(s => s.slug === decodedSlug) : undefined;
 
+  // Unknown slug: render a minimal, ISR-cacheable not-found UI inline.
+  // We deliberately avoid next/navigation's notFound() here — in this
+  // next-intl + on-demand-ISR setup it forces the route dynamic (reads
+  // headers during the not-found boundary render) and returns a 500. The
+  // inline UI keeps the route static/cheap; `robots: noindex` (set in
+  // generateMetadata above) keeps these out of the index.
   if (!song) {
-    return null;
+    return <InlineNotFound />;
   }
 
   const [tMeta, tNav] = await Promise.all([

--- a/apps/main/src/app/[locale]/db/[type]/layout.tsx
+++ b/apps/main/src/app/[locale]/db/[type]/layout.tsx
@@ -12,10 +12,16 @@ export default async function DbTypeLayout({
   const { type } = await params;
 
   if (type === "songs") {
-    const songs = await getAllUniqueSongsCached();
+    // SongsList lives in the shared layout so it NEVER unmounts across
+    // /db/songs ↔ /db/songs/[slug]. It takes no `initialSongs` prop: the
+    // catalog is fetched client-side via tRPC (1h cache). Passing the catalog
+    // as a prop would serialize it into this layout's RSC segment, which is
+    // shared with the detail route — recreating the ISR cost problem. The
+    // list route renders its own SSR <ul> of song links for crawlers; this
+    // component hides it once its interactive grid hydrates.
     return (
       <>
-        <SongsList initialSongs={songs} />
+        <SongsList />
         {children}
       </>
     );

--- a/apps/main/src/app/[locale]/db/[type]/page.tsx
+++ b/apps/main/src/app/[locale]/db/[type]/page.tsx
@@ -1,4 +1,5 @@
 import { getAllUniqueSongsCached } from "@/server/queries/songs-cache";
+import { SongListSeo } from "@/components/db/songs/song-list-seo";
 import { Metadata } from "next";
 import dynamic from "next/dynamic";
 import { Suspense } from "react";
@@ -74,9 +75,9 @@ export default async function DbTypePage({ params }: DbTypePageProps) {
   const { type } = await params;
 
   if (type === "songs") {
-    // The list itself is mounted by /db/[type]/layout.tsx so it persists
-    // across /db/songs ↔ /db/songs/[slug] navigation. This page just emits
-    // page-level structured data.
+    // The interactive SongsList is mounted by /db/[type]/layout (so it
+    // persists across list ↔ detail). This page just emits the SSR
+    // crawlable song-link list (hidden once the grid hydrates) + JSON-LD.
     const songs = await getAllUniqueSongsCached();
     const t = await getTranslations("db.songs.metadata");
 
@@ -89,10 +90,13 @@ export default async function DbTypePage({ params }: DbTypePageProps) {
     };
 
     return (
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
-      />
+      <>
+        <SongListSeo />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
+      </>
     );
   }
 

--- a/apps/main/src/app/api/admin/upload/route.ts
+++ b/apps/main/src/app/api/admin/upload/route.ts
@@ -9,6 +9,9 @@ import { UpdateSong } from "@/lib/types/update";
 import { mergeSongs, taker, merger, key, MergeSink } from "@/server/services/admin/fetcher-utils";
 import { important, PendingSong, value, Pending } from "@/server/utils/admin/type";
 import { sendDiscordNotice, sendDiscordWebhook } from "@/server/services/admin/discord-webhooks";
+import { revalidatePath, revalidateTag } from "next/cache";
+import { getSongSlugs } from "@/lib/song-slug";
+import { locales } from "@tomomai/i18n/locale";
 import { and, eq, inArray, count, sql } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { NextRequest, NextResponse } from "next/server";
@@ -208,6 +211,48 @@ function analyzeChanges(
 }
 
 type UpdateMode = "noop" | "alter" | "destructive";
+
+/**
+ * Push catalog edits to the ISR cache without waiting for the 7-day
+ * revalidate window. Busts the shared songs data cache, then regenerates
+ * each affected song-detail page (per locale) plus the list pages.
+ */
+async function revalidateSongsCache(
+  affected: Array<{ songName: string; artist: string; type: SongType }>,
+  log: (obj: unknown, msg?: string) => void,
+) {
+  revalidateTag("all-unique-songs", { expire: 3600 });
+
+  // Dedupe by songName+type (artist is part of slug derivation only).
+  const seen = new Set<string>();
+  const deduped = affected.filter((s) => {
+    const k = `${s.songName}||${s.type}`;
+    if (seen.has(k)) return false;
+    seen.add(k);
+    return true;
+  });
+
+  const withSlugs = await getSongSlugs(deduped);
+  const slugs = new Set(withSlugs.map((s) => s.slug));
+
+  // Bulk uploads (full catalog re-push) can touch hundreds of songs; fall
+  // back to invalidating the whole dynamic segment instead of thousands of
+  // individual path revalidations.
+  const bulk = slugs.size > 200;
+  for (const locale of locales) {
+    if (bulk) {
+      revalidatePath(`/${locale}/db/songs/[slug]`, "page");
+    } else {
+      for (const slug of slugs) {
+        revalidatePath(`/${locale}/db/songs/${slug}`, "page");
+      }
+    }
+    revalidatePath(`/${locale}/db/songs`, "page");
+  }
+  revalidatePath("/sitemap.xml", "page");
+
+  log({ revalidatedSlugs: slugs.size, bulk }, "ISR cache revalidated");
+}
 
 function pendingSongToDbValues(song: PendingSong, region: Region, gameVersion: VersionId) {
   const noteCounts = value(song.noteCounts as Pending<any>);
@@ -533,6 +578,22 @@ export async function POST(request: NextRequest) {
     const applied = await applyChanges(changes, addedSongs, mergeEvents, region, version, updateMode);
 
     log.info({ updateMode, applied }, "DB update complete");
+
+    // Push the edits to ISR: regenerate affected song pages + bust the catalog
+    // data cache so the next read is fresh. Only when changes were applied.
+    if (updateMode !== "noop") {
+      const affectedSongs = [
+        ...addedSongs.map(s => ({ songName: s.songName, artist: value(s.artist) ?? "", type: s.type })),
+        ...mergeEvents.flatMap(e => [e.existing, e.result])
+          .map(s => ({ songName: s.songName, artist: value(s.artist) ?? "", type: s.type })),
+        ...changes.deleted.map(d => ({ songName: d.songName, artist: d.artist, type: d.type })),
+      ];
+      try {
+        await revalidateSongsCache(affectedSongs, (obj, msg) => log.info(obj, msg ?? ""));
+      } catch (err) {
+        log.error({ err }, "Failed to revalidate songs ISR cache");
+      }
+    }
 
     // Send Discord webhook if changes were applied
     if (updateMode !== "noop") {

--- a/apps/main/src/components/db/songs-list.tsx
+++ b/apps/main/src/components/db/songs-list.tsx
@@ -19,21 +19,22 @@ import { SongRow } from "./songs/song-row";
 import { GroupMode, UniqueSong, UniqueSongFilter, UniqueSongFilterType } from "./songs/types";
 
 interface SongsListProps {
-  /** Server-fetched songs catalog (passed by /db/[type]/layout for type=songs). */
-  initialSongs: UniqueSong[];
+  /** No longer accepts server data — the list is client-fetched via tRPC so it can live in the shared /db/[type]/layout (which keeps it mounted, and thus uncached, across /db/songs ↔ /db/songs/[slug]). */
 }
 
 /**
  * Songs catalog list. Pure list — does NOT own the song-detail drawer.
  *
- * Mounted in /db/[type]/layout.tsx so it persists across /db/songs ↔
- * /db/songs/[slug] navigation (filter/scroll state survives drawer
- * open/close). The selected song highlight is derived from the URL via
- * `usePathname()`, and selecting a song does a soft `router.push` to the
- * slug route — which feeds content into the @detail parallel slot at the
- * /db level, where the drawer wrapper picks it up.
+ * Mounted in /db/[type]/layout.tsx so it NEVER unmounts across
+ * /db/songs ↔ /db/songs/[slug] navigation: filter/search/scroll/visible-count
+ * state survives in plain React state, and the catalog survives in the tRPC
+ * cache (1h). No `initialSongs` prop is accepted — passing it would
+ * serialize the whole catalog into the shared layout's RSC segment and
+ * leak onto the detail route's ISR payload. The /db/songs page renders a
+ * separate SSR <ul> of song links for crawlers; this component hides it
+ * once its interactive grid hydrates.
  */
-export function SongsList({ initialSongs }: SongsListProps) {
+export function SongsList(_: SongsListProps = {}) {
   const t = useTranslations();
   const router = useRouter();
   const pathname = usePathname();
@@ -47,6 +48,12 @@ export function SongsList({ initialSongs }: SongsListProps) {
   const [mounted, setMounted] = useState(false);
   const searchInputRef = useRef<HTMLInputElement>(null);
 
+  // Once the interactive grid hydrates, dismiss the SSR SEO <ul> the list
+  // page rendered (Option B morph: plain list → interactive grid).
+  useEffect(() => {
+    document.getElementById("songs-seo-list")?.setAttribute("hidden", "");
+  }, []);
+
   // Debounce search query
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -54,7 +61,7 @@ export function SongsList({ initialSongs }: SongsListProps) {
       setDebouncedSearchQuery(searchQuery);
     }, 300);
     return () => clearTimeout(timer);
-  }, [searchQuery]);
+  }, [searchQuery, debouncedSearchQuery]);
 
   useEffect(() => {
     setMounted(true);
@@ -64,11 +71,12 @@ export function SongsList({ initialSongs }: SongsListProps) {
   const [groupMode, setGroupMode] = useState<GroupMode>("none");
   const [filters, setFilters] = useState<UniqueSongFilter[]>([]);
 
-  // Use the server-provided initial data; refresh via tRPC client cache.
+  // Catalog is client-fetched via tRPC (1h cache, shared with the detail
+  // route). Keeping it out of props is what lets this component live in the
+  // shared layout without serializing the catalog into the ISR payload.
   const { data: allSongs } = trpc.user.getAllUniqueSongs.useQuery(undefined, {
     staleTime: 3600000, // 1 hour
     refetchOnWindowFocus: false,
-    initialData: initialSongs,
   });
 
   const flattenedSongs = useMemo(() => {

--- a/apps/main/src/components/db/songs/song-card.tsx
+++ b/apps/main/src/components/db/songs/song-card.tsx
@@ -13,9 +13,11 @@ interface SongCardProps {
   index: number;
   isSelected: boolean;
   onSelect: (song: UniqueSong) => void;
+  /** Skip the entrance animation on first mount (set by the list). */
+  disableInitialAnimation?: boolean;
 }
 
-export function SongCard({ song, index, isSelected, onSelect }: SongCardProps) {
+export function SongCard({ song, index, isSelected, onSelect, disableInitialAnimation }: SongCardProps) {
   const href = `/db/songs/${encodeURIComponent(song.slug)}`;
 
   const handleClick = (e: React.MouseEvent) => {
@@ -66,7 +68,7 @@ export function SongCard({ song, index, isSelected, onSelect }: SongCardProps) {
 
   return (
     <motion.div
-      initial={{ opacity: 0, y: 20 }}
+      initial={disableInitialAnimation ? false : { opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{
         duration: 0.4,

--- a/apps/main/src/components/db/songs/song-list-seo.tsx
+++ b/apps/main/src/components/db/songs/song-list-seo.tsx
@@ -1,0 +1,27 @@
+import { getAllUniqueSongsCached } from "@/server/queries/songs-cache";
+
+/**
+ * Server-rendered, crawler-facing list of song links for the /db/songs route.
+ *
+ * SongsList (the interactive grid) lives in the shared /db/[type]/layout and
+ * is client-fetched via tRPC — so song cards are NOT in the initial HTML.
+ * This component puts real, crawlable song names + detail-page links in the
+ * SSR document so the catalog stays indexable. It's hidden client-side once
+ * the interactive grid hydrates (SongsList sets `hidden` on it on mount).
+ *
+ * Rendered only by the list page, so it never leaks onto /db/songs/[slug].
+ */
+export async function SongListSeo() {
+  const songs = await getAllUniqueSongsCached();
+  return (
+    <ul id="songs-seo-list" className="sr-only">
+      {songs.map((song) => (
+        <li key={`${song.slug}-${song.type}`}>
+          <a href={`/db/songs/${encodeURIComponent(song.slug)}`}>
+            {song.songName || song.artist}
+          </a>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/main/src/components/db/songs/song-row.tsx
+++ b/apps/main/src/components/db/songs/song-row.tsx
@@ -12,9 +12,11 @@ interface SongRowProps {
   index: number;
   isSelected: boolean;
   onSelect: (song: UniqueSong) => void;
+  /** Skip the entrance animation on first mount (set by the list). */
+  disableInitialAnimation?: boolean;
 }
 
-export function SongRow({ song, index, isSelected, onSelect }: SongRowProps) {
+export function SongRow({ song, index, isSelected, onSelect, disableInitialAnimation }: SongRowProps) {
   const href = `/db/songs/${encodeURIComponent(song.slug)}`;
   const isSingleDifficulty = song.difficulties.length === 1;
   const singleDiff = isSingleDifficulty ? song.difficulties[0] : null;
@@ -26,7 +28,7 @@ export function SongRow({ song, index, isSelected, onSelect }: SongRowProps) {
 
   return (
     <motion.div
-      initial={{ opacity: 0, x: -10 }}
+      initial={disableInitialAnimation ? false : { opacity: 0, x: -10 }}
       animate={{ opacity: 1, x: 0 }}
       transition={{
         duration: 0.3,

--- a/apps/main/src/components/filter-panel.tsx
+++ b/apps/main/src/components/filter-panel.tsx
@@ -42,6 +42,8 @@ interface FilterPanelProps<T> {
   getFilterLabel: GetFilterLabelFn;
   className?: string;
   triggerClassName?: string;
+  /** Skip entrance animations on first mount (set by the parent list). */
+  disableInitialAnimation?: boolean;
 }
 
 function FilterPanelInner<T>({
@@ -53,6 +55,7 @@ function FilterPanelInner<T>({
   getFilterLabel,
   className,
   triggerClassName,
+  disableInitialAnimation,
 }: FilterPanelProps<T>) {
   const wouldYieldResults = (testFilter: GenericFilter): boolean => {
     // First check if the filter alone yields any results (remove useless filters)
@@ -82,7 +85,7 @@ function FilterPanelInner<T>({
 
   return (
     <motion.div
-      initial={{ height: 0, opacity: 0 }}
+      initial={disableInitialAnimation ? false : { height: 0, opacity: 0 }}
       animate={{ height: "auto", opacity: 1 }}
       exit={{ height: 0, opacity: 0 }}
       transition={{
@@ -92,7 +95,7 @@ function FilterPanelInner<T>({
     >
       <motion.div
         className={cn("space-y-3", className)}
-        initial={{ y: -10 }}
+        initial={disableInitialAnimation ? false : { y: -10 }}
         animate={{ y: 0 }}
         transition={{ duration: 0.3, ease: [0.4, 0, 0.2, 1] }}
       >
@@ -102,7 +105,7 @@ function FilterPanelInner<T>({
             {filters.map((filter, index) => (
               <motion.div
                 key={getFilterKey(filter)}
-                initial={{ width: 0, opacity: 0 }}
+                initial={disableInitialAnimation ? false : { width: 0, opacity: 0 }}
                 animate={{ width: "auto", opacity: 1 }}
                 exit={{ width: 0, opacity: 0 }}
                 transition={{
@@ -136,7 +139,7 @@ function FilterPanelInner<T>({
               return (
                 <motion.div
                   key={category.type}
-                  initial={{ width: 0, opacity: 0 }}
+                  initial={disableInitialAnimation ? false : { width: 0, opacity: 0 }}
                   animate={{ width: "auto", opacity: 1 }}
                   exit={{ width: 0, opacity: 0 }}
                   transition={{

--- a/apps/main/src/components/inline-not-found.tsx
+++ b/apps/main/src/components/inline-not-found.tsx
@@ -1,0 +1,30 @@
+import Link from "next/link";
+
+/**
+ * Minimal not-found UI rendered inline by ISR pages that hit an unknown slug
+ * (e.g. /db/songs/<invalid>). Kept locale-agnostic and free of any dynamic
+ * API read (no headers/cookies/next-intl) so the route stays static and
+ * cheap to revalidate. The caller sets `robots: noindex` in generateMetadata
+ * so these pages don't enter the search index.
+ *
+ * We avoid `notFound()` from next/navigation on purpose: in this app's
+ * next-intl + on-demand-ISR setup, the not-found boundary render reads
+ * headers and flips the route dynamic (HTTP 500).
+ */
+export function InlineNotFound() {
+  return (
+    <main className="flex flex-1 flex-col items-center justify-center gap-4 px-4 py-24 text-center">
+      <p className="text-5xl font-semibold tracking-tight">404</p>
+      <h1 className="text-xl font-medium">Song not found</h1>
+      <p className="max-w-sm text-sm text-muted-foreground">
+        The song you&apos;re looking for doesn&apos;t exist or may have been removed.
+      </p>
+      <Link
+        href="/db/songs"
+        className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+      >
+        Browse songs
+      </Link>
+    </main>
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,7 +118,7 @@ importers:
         version: 9.39.2(jiti@2.6.1)
       eslint-config-next:
         specifier: 16.2.6
-        version: 16.2.6(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+        version: 16.2.6(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       tailwindcss:
         specifier: ^4.1.18
         version: 4.3.0
@@ -458,7 +458,7 @@ importers:
         version: 9.39.2(jiti@2.6.1)
       eslint-config-next:
         specifier: 16.2.6
-        version: 16.2.6(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+        version: 16.2.6(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       playwright:
         specifier: ^1.59.1
         version: 1.59.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,7 +118,7 @@ importers:
         version: 9.39.2(jiti@2.6.1)
       eslint-config-next:
         specifier: 16.2.6
-        version: 16.2.6(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+        version: 16.2.6(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       tailwindcss:
         specifier: ^4.1.18
         version: 4.3.0
@@ -458,7 +458,7 @@ importers:
         version: 9.39.2(jiti@2.6.1)
       eslint-config-next:
         specifier: 16.2.6
-        version: 16.2.6(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+        version: 16.2.6(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       playwright:
         specifier: ^1.59.1
         version: 1.59.1


### PR DESCRIPTION
# perf(main/db): cut song-slug ISR cost ~10x via layout-persistent list

## Why

Follow-up to #44 (the `[locale]` routing PR). That PR moved the catalog subtree to ISR, which worked — but in just 2 days it cost **~$2 in ISR writes with 300k+ write units**. Each `/db/songs/[slug]` regeneration was writing ~1.45 MB / ~185 units per slug per locale (×8 locales).

Debugging revealed the cost driver: `SongsList` lived in the shared `/db/[type]/layout` and received `initialSongs={catalog}`. Next.js serializes client-component props into the RSC payload **even when the component renders nothing** — so the entire ~1.2 MB catalog leaked into the detail route's shared layout segment.

## Root cause → fix

Two problems shared one fix. Dropping the `initialSongs` prop from the layout-persistent `SongsList` (fetching the catalog client-side via tRPC instead) both kills the serialization cost **and** fixes a UX bug — keeping the list in the shared layout means it never unmounts across `list ↔ detail`, eliminating the drawer-open/close flash that a "list in pages" architecture could only paper over with a Zustand store.

## Route manifest (before → after)

| Route | Before | After |
|---|---|---|
| `/db/songs/[slug]` valid | 1.45 MB / 187u | **87 KB / ~11u** |
| `/db/songs/[slug]` invalid | 1.45 MB / **500** | 120 KB / ~15u (no 500) |
| `[type]` layout segment | 1.22 MB | **1 KB** |
| `/db/songs/[slug]` revalidate | 1 day | 14 days + on-demand |

## What changed

- **SongsList back in the shared layout, no `initialSongs`.** The catalog is client-fetched via tRPC (1h cache, shared across list/detail). The `[type]` layout segment drops 1.22 MB → 1 KB. The list never unmounts → no flash/reload on drawer open/close, plain React state survives navigation on its own.
- **`SongListSeo` (new):** a server-rendered `<ul>` of song `<a>` links on the list route only — real crawlable content for SEO (the interactive grid is no longer in initial HTML). SongsList hides it once its grid hydrates (plain-list → grid morph).
- **Removed `songs-list-store` (Zustand)** and the scroll save/restore machinery — no longer needed since the layout persists React state. Uninstalled `zustand`.
- **14-day `revalidate`** on song-slug routes (was 1d) with **on-demand invalidation** from `/api/admin/upload`: `revalidateTag("all-unique-songs")` + `revalidatePath` per affected slug × locale, with a bulk fallback for >200-song uploads.
- **Invalid slugs:** render an `InlineNotFound` UI (`robots: noindex`) instead of `notFound()`. `notFound()` was forcing the ISR route dynamic (500) — the next-intl not-found boundary reads `headers()` in this setup. Verified empirically by reverting.
- **Entrance animations:** `disableInitialAnimation` prop on song cards/rows/filter chips, set on first mount only, so opening the drawer doesn't re-trigger the staggered reveal. Cards added later (infinite scroll, filter changes) still animate.
- **New diagnostic scripts:** `scripts/measure-isr-payload.js` (build-time segment sizes) and `scripts/measure-isr-live.js` (live URL MISS/HIT probes), wired as npm tasks.

## Trade-offs & follow-ups

- The interactive card grid is no longer in `/db/songs` initial HTML — the SSR link-list covers SEO/crawlability (arguably better for Google than JS-driven cards), but a no-JS visitor sees the plain list.
- Invalid-slug routes return HTTP 200 (not 404) with `noindex`. The only Next.js mechanism for a 404 status is `notFound()`, which is incompatible with this next-intl + ISR setup. Junk slugs aren't linked anywhere and are now cheap + cached.
- Pre-existing duplicate-key warnings for 4 utage-variant songs (e.g. `[爆]Love's Theme...` collapses to the same slug as the base song) are unrelated to this PR — noted for a separate fix.

## Verification

- `typecheck` clean, `eslint` 0 errors on changed files, `build` green (440 static pages).
- Live probe (`measure-isr-live.js`) against a local prod build: all HITs, no dynamic errors, payload numbers above.
- Browser test: `[SongsList] MOUNT` fires exactly once; opening/closing the drawer does **not** unmount the list.

## How to measure

```bash
# Build-time (offline):
pnpm --filter @tomomai/site build
node apps/main/scripts/measure-isr-payload.js --dir apps/main/.next

# Live (what Vercel bills):
cd apps/main && PORT=3100 pnpm start   # or point at a deploy
node apps/main/scripts/measure-isr-live.js http://localhost:3100 \
  --slugs "alive-redalice-dx" "_-x0o0x-dx" "coconut" --locale en,ja,zh-TW
```
