### PR TITLE
fix(main/fetch): resolve user flags inside startFetchServer

### DIFF
--- a/apps/main/src/app/api/cn-proxy/callback/route.ts
+++ b/apps/main/src/app/api/cn-proxy/callback/route.ts
@@ -121,7 +121,7 @@ export async function POST(req: NextRequest) {
   // Kick off the fetch on the user's behalf. The dashboard's session
   // polling will pick up the new session id and close the dialog.
   try {
-    const result = await startFetchServer(userId, "cn", undefined, []);
+    const result = await startFetchServer(userId, "cn");
     log.info({ userId, session: result.sessionId }, "started fetch session");
     return NextResponse.json({ ok: true, sessionId: result.sessionId });
   } catch (err) {

--- a/apps/main/src/app/api/v1/fetch/route.ts
+++ b/apps/main/src/app/api/v1/fetch/route.ts
@@ -12,7 +12,7 @@ export const POST = withApiKey(["fetch:start"], async (req: NextRequest, key) =>
   const { region } = parsed;
 
   try {
-    const result = await startFetchServer(key.userId, region, undefined, []);
+    const result = await startFetchServer(key.userId, region);
     return zodJson(spec.response, {
       sessionId: result.sessionId,
       status: result.status,

--- a/apps/main/src/components/dashboard.tsx
+++ b/apps/main/src/components/dashboard.tsx
@@ -85,7 +85,7 @@ export function Dashboard({ user, initialUserData, initialSnapshots, initialSnap
     startSessionPolling,
     stopSessionPolling,
     fetchToastState,
-  } = useFetchSession(refreshSnapshots, flags, () => {
+  } = useFetchSession(refreshSnapshots, () => {
     setDialogType("token");
   }, () => {
     setDialogType("albumPrivacy");

--- a/apps/main/src/hooks/useFetchSession.ts
+++ b/apps/main/src/hooks/useFetchSession.ts
@@ -2,12 +2,11 @@ import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { trpc, trpcClient } from "@/lib/trpc-client";
 import { toast } from "sonner";
 import { Region, FetchSession } from "@/lib/types";
-import { Flags } from "@/lib/flags";
 import { isTokenError, isAlbumSettingsError, isCnCookiesSingleUseError } from "@/lib/token-errors";
 import { parseStatusStates } from "@/lib/fetch-states";
 import { FetchToastState } from "@/components/fetch-toast";
 
-export function useFetchSession(onFetchComplete?: () => void, flags?: Flags, onTokenError?: () => void, onUseAlbumError?: () => void, onCnCookiesExpired?: () => void) {
+export function useFetchSession(onFetchComplete?: () => void, onTokenError?: () => void, onUseAlbumError?: () => void, onCnCookiesExpired?: () => void) {
   const [currentSession, setCurrentSession] = useState<FetchSession | null>(null);
   const [fetchError, setFetchError] = useState<string | null>(null);
   const [lastFetchTime, setLastFetchTime] = useState<Date | null>(null);
@@ -108,14 +107,8 @@ export function useFetchSession(onFetchComplete?: () => void, flags?: Flags, onT
   const startDataFetch = async (region: Region, token?: string): Promise<void> => {
     setFetchError(null);
 
-    // Build flags array for fetch
-    const fetchFlags: string[] = [];
-    if (flags?.eventsCard) {
-      fetchFlags.push("eventsCard");
-    }
-
     // Let the mutation error bubble up to the caller
-    await startFetchMutation.mutateAsync({ region, token, flags: fetchFlags });
+    await startFetchMutation.mutateAsync({ region, token });
   };
 
   // Start automatic fetch using saved token

--- a/apps/main/src/lib/discord/commands/fetch.ts
+++ b/apps/main/src/lib/discord/commands/fetch.ts
@@ -155,7 +155,7 @@ export async function runFetchSession({
 }): Promise<boolean> {
   try {
     // Start the fetch
-    const startResult = await startFetchServer(userId, region, undefined, undefined, { skipAfter: true });
+    const startResult = await startFetchServer(userId, region, undefined, { skipAfter: true });
 
     // Send initial message
     await editDiscordMessage(applicationId, interactionToken, {

--- a/apps/main/src/lib/flags.ts
+++ b/apps/main/src/lib/flags.ts
@@ -70,6 +70,7 @@ type RawFlagConfig = {
 type DefinedFlag = {
   config: FlagDefinition;
   fn: ReturnType<typeof flag<boolean, FlagContext>>;
+  decide: (ctx: FlagContext) => boolean | Promise<boolean>;
 };
 
 const identifyFlagContext = dedupe(async (): Promise<FlagContext> => {
@@ -91,6 +92,7 @@ const identifyFlagContext = dedupe(async (): Promise<FlagContext> => {
 function defineFlag(key: keyof Flags, cfg: RawFlagConfig): DefinedFlag {
   return {
     config: { key, defaultValue: cfg.defaultValue, userSelectable: cfg.userSelectable, category: cfg.category },
+    decide: cfg.decide,
     fn: flag<boolean, FlagContext>({
       key,
       defaultValue: cfg.defaultValue,
@@ -233,6 +235,31 @@ export const useFlags = async (): Promise<Flags> => {
     await Promise.all(Object.entries(registry).map(async ([k, v]) => [k, await v.fn()])),
   ) as Flags;
 };
+
+// Resolve flags from the user's DB row without an HTTP session, so non-request
+// call sites (e.g. the Discord fetch command) honor flagOverrides like the web.
+export async function resolveFlagsForUser(userId: string): Promise<Flags> {
+  const row = await db.query.user.findFirst({
+    where: eq(user.id, userId),
+    columns: { id: true, role: true, flagOverrides: true },
+  });
+  const ctx: FlagContext = {
+    userId: row?.id ?? userId,
+    role: row?.role ?? null,
+    overrides: (row?.flagOverrides as Partial<Flags> | null) ?? {},
+  };
+  const result = {} as Flags;
+  await Promise.all(
+    Object.entries(registry).map(async ([key, defined]) => {
+      const flagKey = key as keyof Flags;
+      const value = defined.config.userSelectable && ctx.overrides[flagKey] != null
+        ? ctx.overrides[flagKey]!
+        : await defined.decide(ctx);
+      result[flagKey] = value;
+    }),
+  );
+  return result;
+}
 
 // Named exports required for Vercel Flags SDK discovery
 // dashboard

--- a/apps/main/src/lib/flags.ts
+++ b/apps/main/src/lib/flags.ts
@@ -252,9 +252,16 @@ export async function resolveFlagsForUser(userId: string): Promise<Flags> {
   await Promise.all(
     Object.entries(registry).map(async ([key, defined]) => {
       const flagKey = key as keyof Flags;
-      const value = defined.config.userSelectable && ctx.overrides[flagKey] != null
-        ? ctx.overrides[flagKey]!
-        : await defined.decide(ctx);
+      let value: boolean;
+      if (defined.config.userSelectable && ctx.overrides[flagKey] != null) {
+        value = ctx.overrides[flagKey]!;
+      } else {
+        try {
+          value = await defined.decide(ctx);
+        } catch {
+          value = defined.config.defaultValue;
+        }
+      }
       result[flagKey] = value;
     }),
   );

--- a/apps/main/src/lib/maimai-server-actions.ts
+++ b/apps/main/src/lib/maimai-server-actions.ts
@@ -10,6 +10,7 @@ import { getAllStates } from './fetch-states';
 import { after } from 'next/server';
 import { flushLogger } from './logger';
 import { getLogger } from './request-logger';
+import { resolveFlagsForUser } from './flags';
 
 export interface StartFetchResult {
   sessionId: string;
@@ -83,7 +84,7 @@ export async function demoFetch(userId: string, region: Region): Promise<StartFe
 }
 
 // Extract startFetch logic from tRPC procedure
-export async function startFetchServer(userId: string, region: Region, token?: string, flags: string[] = [], options?: { skipAfter?: boolean }): Promise<StartFetchResult> {
+export async function startFetchServer(userId: string, region: Region, token?: string, options?: { skipAfter?: boolean }): Promise<StartFetchResult> {
   // Check if demo mode is enabled
   if (process.env.DEMO_FETCH === 'true') {
     return demoFetch(userId, region);
@@ -265,6 +266,7 @@ export async function startFetchServer(userId: string, region: Region, token?: s
       // fetchMaimaiData populates backgroundWorkRef with the optional detail fetches
       // (fetchAndInsertRecentSongsData / fetchAndInsertAlbumData) so the snapshot
       // can be marked completed before those finish.
+      const flags = await resolveFlagsForUser(userId);
       await Promise.race([
         fetchMaimaiData(userId, region, fetchSessionInternalId, flags, shouldFetchAlbums, backgroundWorkRef),
         timeoutPromise

--- a/apps/main/src/lib/maimai/orchestrator.ts
+++ b/apps/main/src/lib/maimai/orchestrator.ts
@@ -45,6 +45,7 @@ import type {
   RecentSongData,
   ScoreData,
 } from "./types";
+import type { Flags } from "../flags";
 
 // ---------------------------------------------------------------------------
 // Shared fetcher contract
@@ -66,7 +67,7 @@ interface FetcherContext {
   userId: string;
   region: Region;
   sessionId: bigint;
-  flags: string[];
+  flags: Flags;
   validation: TokenValidationResult;
 }
 
@@ -170,7 +171,7 @@ const scrapeFetcher: DataFetcher = async ({ userId: _userId, region, sessionId, 
   }
 
   let eventsData: FetchedMaimaiData["eventsData"] = null;
-  if (flags.includes("eventsCard")) {
+  if (flags.eventsCard) {
     try {
       logger.info("Fetching events data...");
       eventsData = await fetchEventsData(cookies, region, sessionId);
@@ -378,7 +379,7 @@ export async function fetchMaimaiData(
   userId: string,
   region: Region,
   sessionId: bigint,
-  flags: string[] = [],
+  flags: Flags,
   shouldFetchAlbums: boolean = false,
   backgroundWorkRef?: { promise: Promise<void> },
 ): Promise<void> {

--- a/apps/main/src/server/routers/user/fetch.ts
+++ b/apps/main/src/server/routers/user/fetch.ts
@@ -36,11 +36,10 @@ export const fetchRouter = router({
     .input(z.object({
       region: regionSchema,
       token: z.string().optional(),
-      flags: z.string().array().default([]),
     }))
     .mutation(async ({ ctx, input }) => {
       try {
-        return await startFetchServer(ctx.session.user.id, input.region as Region, input.token, input.flags);
+        return await startFetchServer(ctx.session.user.id, input.region as Region, input.token);
       } catch (error) {
         if (error instanceof Error) {
           if (isAlbumSettingsError(error.message)) {


### PR DESCRIPTION
## Summary

- Fix Discord-triggered fetches skipping event data because they never received the user's `eventsCard` flag.
- Resolve user flags inside the shared `startFetchServer` entry point instead of passing fetch flags from individual callers.
- Pass the resolved `Flags` object through to `fetchMaimaiData` and check `flags.eventsCard` directly in the orchestrator.
- Remove the tRPC `flags` input and client-side fetch flag mapping so web, Discord, REST, and cn-proxy fetch paths use the same flag resolution.

## Details

Before this change, only the web path built and forwarded fetch flags through tRPC. Discord, `v1/fetch`, and `cn-proxy` passed `flags=[]`, so the orchestrator never entered the events fetch branch gated by `eventsCard`.

`startFetchServer` now resolves the user's flags from the DB via `resolveFlagsForUser(userId)`, making every fetch entry point use the same source of truth.

## Verification

- `pnpm typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Fetch sessions now use your account’s saved settings automatically, so starting a fetch no longer depends on extra hidden inputs.
  * Regional fetch flows were streamlined, including the CN proxy callback path.

* **Bug Fixes**
  * Improved consistency in fetch start handling across the app and server.
  * Fixed fetch startup so the correct settings are applied for each user and region.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->