### PR TITLE
perf(main/api): cache songs catalog across CDN and consumers

### DIFF
--- a/apps/guess/src/lib/song-pool.ts
+++ b/apps/guess/src/lib/song-pool.ts
@@ -3,7 +3,7 @@ import { uniqueSongs, type SongSummary } from "./fuzzy";
 import { hasAudioPreview, isHeardle } from "./heardle";
 
 const DEFAULT_API = "https://www.tomomai.lol";
-const TTL_MS = 60 * 60 * 1000; // 1 hour
+const TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
 
 function apiBase(): string {
   return process.env.TOMOMAI_API_URL?.replace(/\/$/, "") ?? DEFAULT_API;
@@ -13,9 +13,8 @@ async function fetchCatalogue(): Promise<Chart[]> {
   const url = `${apiBase()}/api/v1/songs`;
   // `no-store` is deliberate: the catalogue JSON is ~14 MB, which exceeds
   // Next's 2 MB data-cache cap and would log "items over 2MB can not be
-  // cached" on every call. The module-level memo below (1h TTL) is what
-  // actually keeps this cheap; the network fetch only happens after a cold
-  // start or memo expiry.
+  // cached" on every call. The 24h module-level memo below is the runtime
+  // cache that keeps the cross-app transfer bounded for guess traffic.
   const res = await fetch(url, { cache: "no-store" });
   if (!res.ok) {
     throw new Error(`Failed to fetch song catalogue: ${res.status} ${res.statusText}`);
@@ -52,7 +51,7 @@ function filterPool(all: readonly Chart[]): Chart[] {
 // ---------- In-process cache ---------------------------------------------
 // The catalogue JSON is ~14 MB — too large for Next's unstable_cache (2 MB cap)
 // and pointless to round-trip through that layer anyway. A simple module-level
-// memo with TTL is plenty: each server instance fetches once per hour.
+// memo with a daily TTL matches the daily game cadence and limits refetches.
 
 type CacheEntry<T> = { value: T; expiresAt: number };
 let catalogue: CacheEntry<Chart[]> | Promise<Chart[]> | null = null;

--- a/apps/main/src/app/api/v1/songs/[id]/route.ts
+++ b/apps/main/src/app/api/v1/songs/[id]/route.ts
@@ -5,6 +5,7 @@ import { eq } from "drizzle-orm";
 import { unstable_cache } from "next/cache";
 import { zodJson } from "@/lib/api/zod-response";
 import { spec } from "./spec";
+import { SONG_CATALOG_CACHE_HEADERS } from "../cache-headers";
 
 async function getSongById(songId: string) {
   return unstable_cache(
@@ -84,9 +85,7 @@ export async function GET(
       },
     },
     {
-      headers: {
-        "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400",
-      },
+      headers: SONG_CATALOG_CACHE_HEADERS,
     },
   );
 }

--- a/apps/main/src/app/api/v1/songs/cache-headers.test.ts
+++ b/apps/main/src/app/api/v1/songs/cache-headers.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { SONG_CATALOG_CACHE_HEADERS } from "./cache-headers";
+
+const EXPECTED_SONG_CATALOG_CACHE_VALUE = "public, max-age=3600, stale-while-revalidate=86400";
+
+describe("SONG_CATALOG_CACHE_HEADERS", () => {
+  it("pins the successful song catalog response cache policy for browser, CDN, and Vercel caches", () => {
+    expect(SONG_CATALOG_CACHE_HEADERS).toEqual({
+      "Cache-Control": EXPECTED_SONG_CATALOG_CACHE_VALUE,
+      "CDN-Cache-Control": EXPECTED_SONG_CATALOG_CACHE_VALUE,
+      "Vercel-CDN-Cache-Control": EXPECTED_SONG_CATALOG_CACHE_VALUE,
+    });
+  });
+});

--- a/apps/main/src/app/api/v1/songs/cache-headers.ts
+++ b/apps/main/src/app/api/v1/songs/cache-headers.ts
@@ -1,0 +1,5 @@
+export const SONG_CATALOG_CACHE_HEADERS = {
+  "Cache-Control": "public, max-age=3600, stale-while-revalidate=86400",
+  "CDN-Cache-Control": "public, max-age=3600, stale-while-revalidate=86400",
+  "Vercel-CDN-Cache-Control": "public, max-age=3600, stale-while-revalidate=86400",
+} as const;

--- a/apps/main/src/app/api/v1/songs/route.ts
+++ b/apps/main/src/app/api/v1/songs/route.ts
@@ -3,6 +3,7 @@ import { songs } from "@/lib/db/schema-pg";
 import { unstable_cache } from "next/cache";
 import { zodJson } from "@/lib/api/zod-response";
 import { spec } from "./spec";
+import { SONG_CATALOG_CACHE_HEADERS } from "./cache-headers";
 
 async function getAllSongs() {
   return unstable_cache(
@@ -37,29 +38,25 @@ export async function GET() {
   return zodJson(
     spec.response,
     {
-    songs: allSongs.map((s) => ({
-      songId: s.songId,
-      songName: s.songName,
-      artist: s.artist,
-      cover: s.cover,
-      type: s.type,
-      genre: s.genre,
-      difficulty: s.difficulty,
-      level: s.level,
-      levelPrecise: s.levelPrecise,
-      region: s.region,
-      gameVersion: s.gameVersion,
-      addedVersion: s.addedVersion,
-      bpm: s.bpm,
-      noteDesigner: s.noteDesigner,
-    })),
+      songs: allSongs.map((s) => ({
+        songId: s.songId,
+        songName: s.songName,
+        artist: s.artist,
+        cover: s.cover,
+        type: s.type,
+        genre: s.genre,
+        difficulty: s.difficulty,
+        level: s.level,
+        levelPrecise: s.levelPrecise,
+        region: s.region,
+        gameVersion: s.gameVersion,
+        addedVersion: s.addedVersion,
+        bpm: s.bpm,
+        noteDesigner: s.noteDesigner,
+      })),
     },
     {
-      headers: {
-        // Catalog changes at most hourly; let the CDN serve it without
-        // hitting the function so this stops counting as origin transfer.
-        "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400",
-      },
+      headers: SONG_CATALOG_CACHE_HEADERS,
     },
   );
 }


### PR DESCRIPTION
Share a SONG_CATALOG_CACHE_HEADERS constant (Cache-Control plus CDN and Vercel-CDN variants) across the songs list and detail routes, and bump the guess app's catalogue memo TTL from 1h to 24h to match the daily cadence and cut /api/v1/songs network traffic.