### PR TITLE
fix(main/i18n): swap "My Userscript" with "My App"

### DIFF
--- a/apps/main/messages/en-GB.json
+++ b/apps/main/messages/en-GB.json
@@ -341,7 +341,7 @@
         "editDialog": {
           "title": "Edit API Key",
           "nameLabel": "Name",
-          "namePlaceholder": "My App",
+          "namePlaceholder": "My Userscript",
           "saveButton": "Save",
           "saving": "Saving…",
           "saveError": "Failed to update API key"
@@ -361,7 +361,7 @@
         "saveWarning": "Save this key — it won't be shown again after closing this dialog.",
         "done": "Done",
         "nameLabel": "Name",
-        "namePlaceholder": "My App",
+        "namePlaceholder": "My Userscript",
         "nameDescription": "A descriptive name to identify this key.",
         "scopesLabel": "Scopes",
         "scopeDefaultBadge": "default",
@@ -513,7 +513,7 @@
           "title": "Create OAuth Application",
           "description": "Register a new application to use the OAuth 2.1 authorisation flow.",
           "nameLabel": "Application name",
-          "namePlaceholder": "My Userscript",
+          "namePlaceholder": "My App",
           "nameDescription": "A descriptive name shown to users on the consent screen.",
           "uriLabel": "Application URL",
           "uriPlaceholder": "https://example.com",

--- a/apps/main/messages/en.json
+++ b/apps/main/messages/en.json
@@ -341,7 +341,7 @@
         "editDialog": {
           "title": "Edit API Key",
           "nameLabel": "Name",
-          "namePlaceholder": "My App",
+          "namePlaceholder": "My Userscript",
           "saveButton": "Save",
           "saving": "Saving…",
           "saveError": "Failed to update API key"
@@ -361,7 +361,7 @@
         "saveWarning": "Save this key — it won't be shown again after closing this dialog.",
         "done": "Done",
         "nameLabel": "Name",
-        "namePlaceholder": "My App",
+        "namePlaceholder": "My Userscript",
         "nameDescription": "A descriptive name to identify this key.",
         "scopesLabel": "Scopes",
         "scopeDefaultBadge": "default",
@@ -513,7 +513,7 @@
           "title": "Create OAuth Application",
           "description": "Register a new application to use the OAuth 2.1 authorization flow.",
           "nameLabel": "Application name",
-          "namePlaceholder": "My Userscript",
+          "namePlaceholder": "My App",
           "nameDescription": "A descriptive name shown to users on the consent screen.",
           "uriLabel": "Application URL",
           "uriPlaceholder": "https://example.com",

--- a/apps/main/messages/ja.json
+++ b/apps/main/messages/ja.json
@@ -341,7 +341,7 @@
         "editDialog": {
           "title": "API キーを編集",
           "nameLabel": "名前",
-          "namePlaceholder": "マイアプリ",
+          "namePlaceholder": "マイ Userscript",
           "saveButton": "保存",
           "saving": "保存中…",
           "saveError": "API キーの更新に失敗しました"
@@ -361,7 +361,7 @@
         "saveWarning": "このキーを保存してください。このダイアログを閉じると再表示できません。",
         "done": "完了",
         "nameLabel": "名前",
-        "namePlaceholder": "マイアプリ",
+        "namePlaceholder": "マイ Userscript",
         "nameDescription": "このキーを識別するための名前。",
         "scopesLabel": "スコープ",
         "scopeDefaultBadge": "デフォルト",
@@ -513,7 +513,7 @@
           "title": "OAuth アプリを作成",
           "description": "OAuth 2.1 認可フローを使う新しいアプリを登録します。",
           "nameLabel": "アプリ名",
-          "namePlaceholder": "My Userscript",
+          "namePlaceholder": "マイアプリ",
           "nameDescription": "同意画面でユーザーに表示される説明的な名前。",
           "uriLabel": "アプリ URL",
           "uriPlaceholder": "https://example.com",

--- a/apps/main/messages/ko.json
+++ b/apps/main/messages/ko.json
@@ -288,7 +288,7 @@
         "editDialog": {
           "title": "API 키 편집",
           "nameLabel": "이름",
-          "namePlaceholder": "내 앱",
+          "namePlaceholder": "내 Userscript",
           "saveButton": "저장",
           "saving": "저장 중…",
           "saveError": "API 키 업데이트에 실패했습니다"
@@ -342,7 +342,7 @@
           "title": "OAuth 애플리케이션 생성",
           "description": "OAuth 2.1 인증 흐름을 사용할 새 애플리케이션을 등록합니다.",
           "nameLabel": "애플리케이션 이름",
-          "namePlaceholder": "My Userscript",
+          "namePlaceholder": "내 앱",
           "nameDescription": "동의 화면에서 사용자에게 표시되는 이름입니다.",
           "uriLabel": "애플리케이션 URL",
           "uriPlaceholder": "https://example.com",

--- a/apps/main/messages/zh-CN.json
+++ b/apps/main/messages/zh-CN.json
@@ -341,7 +341,7 @@
         "editDialog": {
           "title": "编辑 API 密钥",
           "nameLabel": "名称",
-          "namePlaceholder": "我的应用",
+          "namePlaceholder": "我的用户脚本",
           "saveButton": "保存",
           "saving": "保存中…",
           "saveError": "更新 API 密钥失败"
@@ -361,7 +361,7 @@
         "saveWarning": "请保存此密钥 —— 关闭此对话框后将无法再次查看。",
         "done": "完成",
         "nameLabel": "名称",
-        "namePlaceholder": "我的应用",
+        "namePlaceholder": "我的用户脚本",
         "nameDescription": "用于识别此密钥的描述性名称。",
         "scopesLabel": "权限范围",
         "scopeDefaultBadge": "默认",
@@ -513,7 +513,7 @@
           "title": "创建 OAuth 应用程序",
           "description": "注册新应用程序以使用 OAuth 2.1 授权流程。",
           "nameLabel": "应用程序名称",
-          "namePlaceholder": "My Userscript",
+          "namePlaceholder": "我的应用",
           "nameDescription": "在同意页面上向用户显示的描述性名称。",
           "uriLabel": "应用程序 URL",
           "uriPlaceholder": "https://example.com",

--- a/apps/main/messages/zh-HK.json
+++ b/apps/main/messages/zh-HK.json
@@ -341,7 +341,7 @@
         "editDialog": {
           "title": "編輯 API 金鑰",
           "nameLabel": "名稱",
-          "namePlaceholder": "我的應用程式",
+          "namePlaceholder": "我的 Userscript",
           "saveButton": "儲存",
           "saving": "儲存中……",
           "saveError": "更新 API 金鑰失敗"
@@ -361,7 +361,7 @@
         "saveWarning": "請儲存此金鑰 — 關閉此對話框後將無法再次查看。",
         "done": "完成",
         "nameLabel": "名稱",
-        "namePlaceholder": "我的應用程式",
+        "namePlaceholder": "我的 Userscript",
         "nameDescription": "一個用於辨識此金鑰的描述性名稱。",
         "scopesLabel": "權限範圍",
         "scopeDefaultBadge": "預設",
@@ -513,7 +513,7 @@
           "title": "建立 OAuth 應用程式",
           "description": "註冊一個新應用程式以使用 OAuth 2.1 授權流程。",
           "nameLabel": "應用程式名稱",
-          "namePlaceholder": "我的 Userscript",
+          "namePlaceholder": "我的應用程式",
           "nameDescription": "在同意畫面上向用戶顯示的描述性名稱。",
           "uriLabel": "應用程式網址",
           "uriPlaceholder": "https://example.com",

--- a/apps/main/messages/zh-SG.json
+++ b/apps/main/messages/zh-SG.json
@@ -351,7 +351,7 @@
         "editDialog": {
           "title": "编辑 API 金钥",
           "nameLabel": "名称",
-          "namePlaceholder": "我的应用程式",
+          "namePlaceholder": "我的用户脚本",
           "saveButton": "储存",
           "saving": "储存中……",
           "saveError": "更新 API 金钥失败"
@@ -371,7 +371,7 @@
         "saveWarning": "请保存此密钥 —— 关闭此对话框后将无法再次查看。",
         "done": "完成",
         "nameLabel": "名称",
-        "namePlaceholder": "我的应用",
+        "namePlaceholder": "我的用户脚本",
         "nameDescription": "用于识别此密钥的描述性名称。",
         "scopesLabel": "权限范围",
         "scopeDefaultBadge": "默认",
@@ -523,7 +523,7 @@
           "title": "建立 OAuth 应用程式",
           "description": "注册新应用程式以使用 OAuth 2.1 授权流程。",
           "nameLabel": "应用程式名称",
-          "namePlaceholder": "My Userscript",
+          "namePlaceholder": "我的应用程式",
           "nameDescription": "在同意画面上向用户显示的描述性名称。",
           "uriLabel": "应用程式网址",
           "uriPlaceholder": "https://example.com",

--- a/apps/main/messages/zh-TW.json
+++ b/apps/main/messages/zh-TW.json
@@ -341,7 +341,7 @@
         "editDialog": {
           "title": "編輯 API 金鑰",
           "nameLabel": "名稱",
-          "namePlaceholder": "我的應用程式",
+          "namePlaceholder": "我的使用者腳本",
           "saveButton": "儲存",
           "saving": "儲存中…",
           "saveError": "更新 API 金鑰失敗"
@@ -361,7 +361,7 @@
         "saveWarning": "請儲存此金鑰 — 關閉此對話框後將無法再次查看。",
         "done": "完成",
         "nameLabel": "名稱",
-        "namePlaceholder": "我的應用程式",
+        "namePlaceholder": "我的使用者腳本",
         "nameDescription": "用於辨識此金鑰的名稱。",
         "scopesLabel": "權限範圍",
         "scopeDefaultBadge": "預設",
@@ -513,7 +513,7 @@
           "title": "建立 OAuth 應用程式",
           "description": "註冊新應用程式以使用 OAuth 2.1 授權流程。",
           "nameLabel": "應用程式名稱",
-          "namePlaceholder": "我的使用者腳本",
+          "namePlaceholder": "我的應用程式",
           "nameDescription": "在授權同意畫面上顯示給使用者的描述性名稱。",
           "uriLabel": "應用程式網址",
           "uriPlaceholder": "https://example.com",


### PR DESCRIPTION
The placeholder text for API key creation/editing is "My App" while OAuth Apps uses "My Userscript"; swapping them should be more correct. This PR does that and add translations of several untranslated strings of the same key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Updated name-field placeholder text across API key and OAuth application dialogs.
  * API key dialogs now suggest a userscript name, while OAuth application creation dialogs use an application name.
  * Applied the corrections across English, Japanese, Korean, Simplified Chinese, and Traditional Chinese locales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->