### PR TITLE
fix(main/ui): restore pre-maintenance banner

### DIFF
--- a/apps/main/src/app/[locale]/layout.tsx
+++ b/apps/main/src/app/[locale]/layout.tsx
@@ -15,6 +15,7 @@ import { DEFAULT_THEME_ID, getThemeOrDefault, getThemeStyleProperties, themeNoFl
 import { resolveBaseUrl } from '@/lib/base-url';
 import { siteJsonLd } from '@/lib/seo';
 import { SiteFooter } from '@/components/site-footer';
+import { PreMaintenanceBanner } from '@/components/pre-maintenance-banner';
 
 const inter = localFont({
   src: "../../../public/res/fonts/Inter-VariableFont_opsz_wght.woff2",
@@ -96,6 +97,7 @@ export default async function LocaleLayout({ children, params }: Props) {
           <LocaleProvider initialLocale={typedLocale}>
             <ThemeProvider>
               <TRPCProvider>
+                <PreMaintenanceBanner />
                 {children}
                 <SiteFooter />
                 {shouldInjectToolbar && <VercelToolbar />}

--- a/apps/main/src/app/api/pre-maintenance/parse.ts
+++ b/apps/main/src/app/api/pre-maintenance/parse.ts
@@ -1,0 +1,22 @@
+export interface PreMaintenanceBannerData {
+  title: string;
+  description: string;
+  raw: string;
+}
+
+export function parsePreMaintenanceBanner(value: unknown): PreMaintenanceBannerData | null {
+  if (typeof value !== "string" || value.length === 0) {
+    return null;
+  }
+
+  const parts = value.split("||");
+  if (parts.length < 2) {
+    return null;
+  }
+
+  return {
+    title: parts[0].trim(),
+    description: parts.slice(1).join("||").trim(),
+    raw: value,
+  };
+}

--- a/apps/main/src/app/api/pre-maintenance/route.ts
+++ b/apps/main/src/app/api/pre-maintenance/route.ts
@@ -1,0 +1,24 @@
+import { getCachedEdgeConfig } from "@/lib/edge-config-cache";
+import { NextResponse } from "next/server";
+import { parsePreMaintenanceBanner } from "./parse";
+
+const CACHE_HEADERS = {
+  "Cache-Control": "public, max-age=300",
+  "CDN-Cache-Control": "public, s-maxage=300",
+  "Vercel-CDN-Cache-Control": "public, s-maxage=300",
+} as const;
+
+export async function GET() {
+  try {
+    const value = await getCachedEdgeConfig<string>("preMaintenanceMode");
+    return NextResponse.json(
+      { banner: parsePreMaintenanceBanner(value) },
+      { headers: CACHE_HEADERS },
+    );
+  } catch {
+    return NextResponse.json(
+      { banner: null },
+      { status: 503, headers: CACHE_HEADERS },
+    );
+  }
+}

--- a/apps/main/src/components/pre-maintenance-banner.tsx
+++ b/apps/main/src/components/pre-maintenance-banner.tsx
@@ -1,30 +1,70 @@
 "use client";
 
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { TriangleAlert, X } from 'lucide-react';
 
 const STORAGE_KEY = 'dismissed-pre-maintenance';
 
-interface Props {
+interface Banner {
   title: string;
   description: string;
   raw: string;
 }
 
-export function PreMaintenanceBanner({ title, description, raw }: Props) {
-  const [visible, setVisible] = useState(false);
+function isBanner(value: unknown): value is Banner {
+  if (typeof value !== 'object' || value === null) return false;
+
+  const banner = value as Record<string, unknown>;
+  return (
+    typeof banner.title === 'string' &&
+    typeof banner.description === 'string' &&
+    typeof banner.raw === 'string'
+  );
+}
+
+export function PreMaintenanceBanner() {
+  const [banner, setBanner] = useState<Banner | null>(null);
 
   useEffect(() => {
-    if (localStorage.getItem(STORAGE_KEY) !== raw) {
-      setVisible(true);
-    }
-  }, [raw]);
+    const controller = new AbortController();
 
-  if (!visible) return null;
+    async function loadBanner() {
+      try {
+        const response = await fetch('/api/pre-maintenance', {
+          signal: controller.signal,
+        });
+        if (!response.ok) return;
+
+        const payload: unknown = await response.json();
+        if (
+          typeof payload !== 'object' ||
+          payload === null ||
+          !('banner' in payload) ||
+          !isBanner(payload.banner)
+        ) {
+          return;
+        }
+
+        if (localStorage.getItem(STORAGE_KEY) !== payload.banner.raw) {
+          setBanner(payload.banner);
+        }
+      } catch {
+        // Fetch and response errors intentionally leave the banner hidden.
+      }
+    }
+
+    void loadBanner();
+
+    return () => controller.abort();
+  }, []);
+
+  if (!banner) return null;
+
+  const { title, description, raw } = banner;
 
   function dismiss() {
     localStorage.setItem(STORAGE_KEY, raw);
-    setVisible(false);
+    setBanner(null);
   }
 
   return (


### PR DESCRIPTION
## Why

PR #44 removed the `preMaintenanceMode` Edge Config read while moving locale routes to static/ISR rendering. The existing banner component remained unused.

## What changed

- fetch `preMaintenanceMode` through a dedicated client-called API route
- preserve the existing `title||description` format and per-value dismissal
- cache API responses for five minutes in browsers and shared CDNs
- keep the locale layout free of request-time Edge Config reads so static/ISR caching remains intact

## Verification

- `pnpm typecheck`
- `pnpm build` (451 static pages generated; catalog routes remain SSG/ISR)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a pre-maintenance banner to the application layout.
  * Banner content is retrieved dynamically and displayed only when valid maintenance information is available.
  * Added support for dismissing a banner until its content changes.

* **Bug Fixes**
  * Prevented banner-related loading or response errors from disrupting the application.
  * Added graceful handling when maintenance information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->