### PR TITLE
fix(main/discord): render fetch failure reason

### DIFF
--- a/apps/main/src/lib/discord/commands/fetch.ts
+++ b/apps/main/src/lib/discord/commands/fetch.ts
@@ -240,7 +240,7 @@ async function pollForUpdates(
             await editDiscordMessage(applicationId, interactionToken, {
               embeds: [{
                 title: t(locale, 'fetch.failed.title'),
-                description: t(locale, 'fetch.failed.description', { userId: discordUserId, regionName }),
+                description: t(locale, 'fetch.failed.description', { userId: discordUserId, regionName, reason: failureReason }),
                 color: DISCORD_COLORS.RED,
                 footer: {
                   text: t(locale, 'common.footer'),


### PR DESCRIPTION
## Summary
- include the stored fetch failure reason in localized Discord failure responses
- prevent `{reason}` from appearing literally in failed `/fetch` messages
- audit all Discord translation callsites and supported locales for similar missing interpolation arguments

## Verification
- `pnpm --filter @tomomai/site typecheck`
- focused Vitest smoke check for the Japanese failure rendering (temporary test file removed before commit)

No test or smoke files are included in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Discord fetch failure messages by including the specific reason for the failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->