### PR TITLE
perf(main): reduce Vercel origin, ISR, and compute usage

### DIFF
--- a/apps/main/src/app/[locale]/profile/[username]/[region]/page.tsx
+++ b/apps/main/src/app/[locale]/profile/[username]/[region]/page.tsx
@@ -12,7 +12,7 @@ import { getLocale, setStaticLocale } from "@/i18n/locale-server";
 import { buildAlternates, openGraphLocales, breadcrumbJsonLd, ogImageUrl, localizePath } from "@/lib/seo";
 import { safeDecodeURIComponent } from "@/lib/utils";
 
-export const revalidate = 300;
+export const revalidate = 3600;
 export const dynamicParams = true;
 
 export function generateStaticParams() {

--- a/apps/main/src/app/[locale]/settings/layout.tsx
+++ b/apps/main/src/app/[locale]/settings/layout.tsx
@@ -32,6 +32,7 @@ export default async function SettingsLayout({
             width={4320}
             height={1080}
             priority
+            sizes="176px"
             className="h-11 w-auto dark:hidden"
             style={{ aspectRatio: "4320 / 1080" }}
           />
@@ -40,8 +41,8 @@ export default async function SettingsLayout({
             alt="tomomai"
             width={4320}
             height={1080}
-            priority
             className="h-11 w-auto hidden dark:block"
+            sizes="176px"
             style={{ aspectRatio: "4320 / 1080" }}
           />
         </Link>

--- a/apps/main/src/app/api/admin/upload/route.ts
+++ b/apps/main/src/app/api/admin/upload/route.ts
@@ -9,6 +9,7 @@ import { UpdateSong } from "@/lib/types/update";
 import { mergeSongs, taker, merger, key, MergeSink } from "@/server/services/admin/fetcher-utils";
 import { important, PendingSong, value, Pending } from "@/server/utils/admin/type";
 import { sendDiscordNotice, sendDiscordWebhook } from "@/server/services/admin/discord-webhooks";
+import { publishSongCatalog } from "@/server/services/admin/song-catalog";
 import { revalidatePath, revalidateTag } from "next/cache";
 import { getSongSlugs } from "@/lib/song-slug";
 import { locales } from "@tomomai/i18n/locale";
@@ -213,32 +214,30 @@ function analyzeChanges(
 type UpdateMode = "noop" | "alter" | "destructive";
 
 /**
- * Push catalog edits to the ISR cache without waiting for the 7-day
+ * Push catalog edits to the ISR cache without waiting for the 14-day
  * revalidate window. Busts the shared songs data cache, then regenerates
  * each affected song-detail page (per locale) plus the list pages.
  */
 async function revalidateSongsCache(
   affected: Array<{ songName: string; artist: string; type: SongType }>,
   log: (obj: unknown, msg?: string) => void,
+  forceBulk = false,
 ) {
   revalidateTag("all-unique-songs", { expire: 3600 });
 
-  // Dedupe by songName+type (artist is part of slug derivation only).
   const seen = new Set<string>();
-  const deduped = affected.filter((s) => {
-    const k = `${s.songName}||${s.type}`;
-    if (seen.has(k)) return false;
-    seen.add(k);
+  const deduped = affected.filter((song) => {
+    const key = `${song.songName}||${song.artist}||${song.type}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
     return true;
   });
 
   const withSlugs = await getSongSlugs(deduped);
-  const slugs = new Set(withSlugs.map((s) => s.slug));
+  const slugs = new Set(withSlugs.map((song) => song.slug));
 
-  // Bulk uploads (full catalog re-push) can touch hundreds of songs; fall
-  // back to invalidating the whole dynamic segment instead of thousands of
-  // individual path revalidations.
-  const bulk = slugs.size > 200;
+  // Bulk uploads can touch hundreds of songs, so avoid thousands of calls.
+  const bulk = forceBulk || slugs.size > 200;
   for (const locale of locales) {
     if (bulk) {
       revalidatePath(`/${locale}/db/songs/[slug]`, "page");
@@ -298,9 +297,13 @@ async function applyChanges(
   let appliedDeleted = 0;
 
   // Update modified songs
-  if (mergeEvents.length > 0) {
+  if (changes.modified.length > 0) {
+    const modifiedDbIds = new Set(changes.modified.map(change => change.dbId));
     const modifiedRows = mergeEvents
-      .filter(({ existing }) => existing.extras?.dbId)
+      .filter(({ existing }) => {
+        const dbId = existing.extras?.dbId;
+        return dbId && modifiedDbIds.has(String(dbId));
+      })
       .map(({ result }) => pendingSongToDbValues(result, region, version));
 
     const batchSize = 1000;
@@ -577,19 +580,36 @@ export async function POST(request: NextRequest) {
     // Apply DB changes if requested
     const applied = await applyChanges(changes, addedSongs, mergeEvents, region, version, updateMode);
 
+    const appliedCount = applied.added + applied.modified + applied.deleted;
+    if (updateMode !== "noop") {
+      // Publish first: ISR invalidation must never advertise catalog changes
+      // while the stable API object still contains the previous DB state.
+      const publication = await publishSongCatalog();
+      log.info(publication, "Published public song catalog to R2");
+    }
+
     log.info({ updateMode, applied }, "DB update complete");
 
-    // Push the edits to ISR: regenerate affected song pages + bust the catalog
-    // data cache so the next read is fresh. Only when changes were applied.
+    // Push only committed edits to ISR; preserve both slug inputs for renames.
     if (updateMode !== "noop") {
+      const modifiedDbIds = new Set(changes.modified.map(change => change.dbId));
+      const modifiedSongs = mergeEvents
+        .filter(({ existing }) => {
+          const dbId = existing.extras?.dbId;
+          return dbId && modifiedDbIds.has(String(dbId));
+        })
+        .flatMap(({ existing, result }) => [existing, result])
+        .map(song => ({ songName: song.songName, artist: value(song.artist) ?? "", type: song.type }));
+      const appliedDeletions = (updateMode === "destructive"
+        ? changes.deleted
+        : changes.deleted.filter(change => (change.playRecordCount ?? 0) === 0));
       const affectedSongs = [
-        ...addedSongs.map(s => ({ songName: s.songName, artist: value(s.artist) ?? "", type: s.type })),
-        ...mergeEvents.flatMap(e => [e.existing, e.result])
-          .map(s => ({ songName: s.songName, artist: value(s.artist) ?? "", type: s.type })),
-        ...changes.deleted.map(d => ({ songName: d.songName, artist: d.artist, type: d.type })),
+        ...addedSongs.map(song => ({ songName: song.songName, artist: value(song.artist) ?? "", type: song.type })),
+        ...modifiedSongs,
+        ...appliedDeletions.map(change => ({ songName: change.songName, artist: change.artist, type: change.type })),
       ];
       try {
-        await revalidateSongsCache(affectedSongs, (obj, msg) => log.info(obj, msg ?? ""));
+        await revalidateSongsCache(affectedSongs, (obj, msg) => log.info(obj, msg ?? ""), appliedCount === 0);
       } catch (err) {
         log.error({ err }, "Failed to revalidate songs ISR cache");
       }

--- a/apps/main/src/app/api/v1/songs/cache-headers.test.ts
+++ b/apps/main/src/app/api/v1/songs/cache-headers.test.ts
@@ -1,7 +1,18 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { SONG_CATALOG_CACHE_HEADERS } from "./cache-headers";
+import { GET } from "./route";
 
 const EXPECTED_SONG_CATALOG_CACHE_VALUE = "public, max-age=3600, stale-while-revalidate=86400";
+
+const originalR2Url = process.env.NEXT_PUBLIC_R2_URL;
+
+afterEach(() => {
+  if (originalR2Url === undefined) {
+    delete process.env.NEXT_PUBLIC_R2_URL;
+  } else {
+    process.env.NEXT_PUBLIC_R2_URL = originalR2Url;
+  }
+});
 
 describe("SONG_CATALOG_CACHE_HEADERS", () => {
   it("pins the successful song catalog response cache policy for browser, CDN, and Vercel caches", () => {
@@ -10,5 +21,17 @@ describe("SONG_CATALOG_CACHE_HEADERS", () => {
       "CDN-Cache-Control": EXPECTED_SONG_CATALOG_CACHE_VALUE,
       "Vercel-CDN-Cache-Control": EXPECTED_SONG_CATALOG_CACHE_VALUE,
     });
+  });
+
+  it("redirects the stable API path to the R2 catalog with the shared cache policy", () => {
+    process.env.NEXT_PUBLIC_R2_URL = "https://cdn.example.test/";
+
+    const response = GET();
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe("https://cdn.example.test/api/v1/songs");
+    for (const [name, value] of Object.entries(SONG_CATALOG_CACHE_HEADERS)) {
+      expect(response.headers.get(name)).toBe(value);
+    }
   });
 });

--- a/apps/main/src/app/api/v1/songs/route.ts
+++ b/apps/main/src/app/api/v1/songs/route.ts
@@ -1,62 +1,16 @@
-import { db } from "@/lib/db";
-import { songs } from "@/lib/db/schema-pg";
-import { unstable_cache } from "next/cache";
-import { zodJson } from "@/lib/api/zod-response";
-import { spec } from "./spec";
 import { SONG_CATALOG_CACHE_HEADERS } from "./cache-headers";
 
-async function getAllSongs() {
-  return unstable_cache(
-    async () => {
-      return db
-        .select({
-          songId: songs.publicId,
-          songName: songs.songName,
-          artist: songs.artist,
-          cover: songs.cover,
-          type: songs.type,
-          genre: songs.genre,
-          difficulty: songs.difficulty,
-          level: songs.level,
-          levelPrecise: songs.levelPrecise,
-          region: songs.region,
-          gameVersion: songs.gameVersion,
-          addedVersion: songs.addedVersion,
-          bpm: songs.bpm,
-          noteDesigner: songs.noteDesigner,
-        })
-        .from(songs)
-        .orderBy(songs.songName, songs.difficulty);
-    },
-    ["api-v1-songs"],
-    { revalidate: 3600, tags: ["api-v1-songs"] }
-  )();
-}
+export function GET() {
+  const r2BaseUrl = process.env.NEXT_PUBLIC_R2_URL;
+  if (!r2BaseUrl) {
+    throw new Error("NEXT_PUBLIC_R2_URL is required for the song catalog redirect");
+  }
 
-export async function GET() {
-  const allSongs = await getAllSongs();
-  return zodJson(
-    spec.response,
-    {
-      songs: allSongs.map((s) => ({
-        songId: s.songId,
-        songName: s.songName,
-        artist: s.artist,
-        cover: s.cover,
-        type: s.type,
-        genre: s.genre,
-        difficulty: s.difficulty,
-        level: s.level,
-        levelPrecise: s.levelPrecise,
-        region: s.region,
-        gameVersion: s.gameVersion,
-        addedVersion: s.addedVersion,
-        bpm: s.bpm,
-        noteDesigner: s.noteDesigner,
-      })),
+  return new Response(null, {
+    status: 302,
+    headers: {
+      ...SONG_CATALOG_CACHE_HEADERS,
+      Location: `${r2BaseUrl.replace(/\/$/, "")}/api/v1/songs`,
     },
-    {
-      headers: SONG_CATALOG_CACHE_HEADERS,
-    },
-  );
+  });
 }

--- a/apps/main/src/app/api/v1/songs/spec.ts
+++ b/apps/main/src/app/api/v1/songs/spec.ts
@@ -1,6 +1,5 @@
-import { z } from "zod";
 import { defineRoute } from "@/lib/api/registry";
-import { songCatalogueEntry } from "@/lib/api/schemas";
+import { songCatalogue } from "@/lib/api/schemas";
 
 export const spec = defineRoute({
   method: "GET",
@@ -12,7 +11,5 @@ export const spec = defineRoute({
   scope: "public",
   cost: 1,
   cacheSeconds: 3600,
-  response: z.object({
-    songs: z.array(songCatalogueEntry),
-  }),
+  response: songCatalogue,
 });

--- a/apps/main/src/app/robots.ts
+++ b/apps/main/src/app/robots.ts
@@ -1,7 +1,6 @@
 import { resolveBaseUrl } from '@/lib/base-url'
 import type { MetadataRoute } from 'next'
 
-export const revalidate = 21600
 
 export default function robots(): MetadataRoute.Robots {
   return {

--- a/apps/main/src/components/db/songs/song-card.tsx
+++ b/apps/main/src/components/db/songs/song-card.tsx
@@ -101,6 +101,7 @@ export function SongCard({ song, index, isSelected, onSelect, disableInitialAnim
           fill
           className="object-cover"
           loading="lazy"
+          sizes="(min-width: 1280px) 12.5vw, (min-width: 1024px) 14.3vw, (min-width: 768px) 16.7vw, (min-width: 640px) 20vw, (min-width: 475px) 25vw, 33.3vw"
         />
 
         {/* Dark overlay */}

--- a/apps/main/src/components/db/songs/song-detail-content.tsx
+++ b/apps/main/src/components/db/songs/song-detail-content.tsx
@@ -340,6 +340,7 @@ export function SongDetailContent({ songName, slug, type, initialData }: SongDet
             alt={data.songName}
             fill
             className="object-cover"
+            sizes="(max-width: 767px) 80px, 96px"
           />
         </div>
         <div className="flex-1 min-w-0 my-auto">

--- a/apps/main/src/components/db/stats/song-ranking-table.tsx
+++ b/apps/main/src/components/db/stats/song-ranking-table.tsx
@@ -55,6 +55,7 @@ export function SongRankingTable({ data, collapsedCount = 5 }: SongRankingTableP
                   fill
                   className="object-cover"
                   loading="lazy"
+                  sizes="40px"
                 />
               </div>
               <div className="flex flex-col min-w-0">

--- a/apps/main/src/components/events-card.tsx
+++ b/apps/main/src/components/events-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { SnapshotWithSongs } from "@/lib/types";
-import { cn, createSafeMaimaiImageUrl } from "@/lib/utils";
+import { cn, createSafeMaimaiImageUrl, isR2Url } from "@/lib/utils";
 import { Map, Calendar, Flag, CheckCircle2, Loader2 } from "lucide-react";
 import { useTranslations } from "next-intl";
 import Image from "next/image";
@@ -132,6 +132,8 @@ function EventCard({
           width={80}
           height={80}
           loading="lazy"
+          sizes="(min-width: 475px) 80px, 64px"
+          unoptimized={isR2Url(event.imageUrl)}
         />
 
         <div className="flex-1 min-w-0">

--- a/apps/main/src/components/mdx-base-components.tsx
+++ b/apps/main/src/components/mdx-base-components.tsx
@@ -54,6 +54,7 @@ export const mdxBaseComponents = {
       width={800}
       height={600}
       className="rounded-lg my-6 w-[70%] h-auto max-h-[32rem] object-contain mx-auto"
+      sizes="70vw"
     />
   ),
 } as const;

--- a/apps/main/src/components/mdx-image-carousel.tsx
+++ b/apps/main/src/components/mdx-image-carousel.tsx
@@ -40,6 +40,7 @@ export function MdxImageCarouselSlide({
           width={800}
           height={600}
           className="rounded-lg w-auto max-w-full max-h-[32rem]"
+          sizes="80vw"
           draggable={false}
         />
         {caption && (

--- a/apps/main/src/components/mdx-image-comparison.tsx
+++ b/apps/main/src/components/mdx-image-comparison.tsx
@@ -25,6 +25,7 @@ export function MdxImageComparison({
         width={800}
         height={600}
         className="invisible w-full h-auto"
+        sizes="70vw"
         aria-hidden="true"
         draggable={false}
       />
@@ -35,6 +36,7 @@ export function MdxImageComparison({
           width={800}
           height={600}
           className="size-full object-contain"
+          sizes="70vw"
           draggable={false}
         />
       </ComparisonItem>
@@ -45,6 +47,7 @@ export function MdxImageComparison({
           width={800}
           height={600}
           className="size-full object-contain"
+          sizes="70vw"
           draggable={false}
         />
       </ComparisonItem>

--- a/apps/main/src/components/song-hover-card.tsx
+++ b/apps/main/src/components/song-hover-card.tsx
@@ -109,6 +109,7 @@ function SongCardContent({
             alt={song.songName}
             fill
             className="object-cover"
+            sizes="64px"
           />
         </div>
         <div className="flex-1 min-w-0 py-0.5">

--- a/apps/main/src/components/songs-card.tsx
+++ b/apps/main/src/components/songs-card.tsx
@@ -169,6 +169,7 @@ const SongRow = forwardRef<HTMLDivElement, { song: SongWithRating; percentile?: 
           width={36}
           height={36}
           loading="lazy"
+          sizes="32px"
         />
         <div className="flex-1 min-w-0">
           <div className="truncate font-medium">{song.songName}&#8203;</div>
@@ -377,6 +378,7 @@ export const SongGridCard = forwardRef<HTMLDivElement, { song: MinimalSongForDis
           fill
           className="object-cover rounded-[8px] overflow-hidden"
           loading="lazy"
+          sizes="(min-width: 1024px) 20vw, (min-width: 640px) 33.3vw, (min-width: 375px) 50vw, 100vw"
         />
 
         {/* Dark overlay for text readability */}

--- a/apps/main/src/hooks/useFetchSession.ts
+++ b/apps/main/src/hooks/useFetchSession.ts
@@ -16,16 +16,107 @@ export function useFetchSession(onFetchComplete?: () => void, onTokenError?: () 
   const [sessionPollingRegion, setSessionPollingRegion] = useState<Region | null>(null);
   const lastKnownSessionIdRef = useRef<string | null>(null);
   const onSessionDetectedRef = useRef<(() => void) | undefined>(undefined);
+  const fetchPollingTimeoutRef = useRef<number | null>(null);
+  const fetchPollingGenerationRef = useRef(0);
 
   // Poll for new fetch sessions (lightweight query)
   const { data: latestSessionData } = trpc.user.getLatestFetchSessionId.useQuery(
     { region: sessionPollingRegion! },
     {
       enabled: sessionPollingEnabled && sessionPollingRegion !== null,
-      refetchInterval: 1000, // Poll every 1 seconds
+      refetchInterval: 2000, // Poll every 2 seconds
       refetchOnWindowFocus: false,
     }
   );
+
+  const pollFetchStatus = useCallback((sessionId: string, region: Region) => {
+    const deadline = Date.now() + 5 * 60 * 1000;
+    const generation = ++fetchPollingGenerationRef.current;
+
+    if (fetchPollingTimeoutRef.current !== null) {
+      window.clearTimeout(fetchPollingTimeoutRef.current);
+      fetchPollingTimeoutRef.current = null;
+    }
+
+    const stopPolling = () => {
+      if (fetchPollingTimeoutRef.current !== null) {
+        window.clearTimeout(fetchPollingTimeoutRef.current);
+        fetchPollingTimeoutRef.current = null;
+      }
+    };
+
+    const poll = async () => {
+      if (generation !== fetchPollingGenerationRef.current) return;
+      if (Date.now() >= deadline) {
+        stopPolling();
+        setFetchError("Fetch timeout");
+        return;
+      }
+
+      try {
+        const result = await trpcClient.user.getFetchStatus.query({ region });
+
+        if (generation !== fetchPollingGenerationRef.current) return;
+
+        if (result && result.id === sessionId) {
+          const updatedSession: FetchSession = {
+            id: result.id,
+            status: result.status,
+            startedAt: result.startedAt,
+            completedAt: result.completedAt || undefined,
+            errorMessage: result.errorMessage || undefined,
+            statusStates: result.statusStates || undefined,
+          };
+          console.log("Fetch status updated for session " + sessionId + " on " + region + " region: " + JSON.stringify(updatedSession));
+          setCurrentSession(updatedSession);
+
+          if (result.status === "completed") {
+            stopPolling();
+            if (result.notFoundScores && result.notFoundScores.length > 0) {
+              toast.warning(`${result.notFoundScores.length} songs not found in database`, {
+                description: result.notFoundScores.map(score => `${score.songName} (${score.difficulty})`).join(", "),
+              });
+            }
+            onFetchComplete?.();
+            return;
+          }
+
+          if (result.status === "failed") {
+            stopPolling();
+            const errorMessage = result.errorMessage || "Fetch failed";
+            setFetchError(errorMessage);
+
+            if (isTokenError(errorMessage)) {
+              onTokenError?.();
+            }
+            if (isAlbumSettingsError(errorMessage)) {
+              onUseAlbumError?.();
+            }
+            return;
+          }
+        } else if (!result) {
+          stopPolling();
+          setFetchError("Fetch session not found");
+          return;
+        }
+
+        const remaining = deadline - Date.now();
+        if (remaining <= 0) {
+          stopPolling();
+          setFetchError("Fetch timeout");
+          return;
+        }
+        fetchPollingTimeoutRef.current = window.setTimeout(poll, Math.min(1000, remaining));
+      } catch (error) {
+        if (generation !== fetchPollingGenerationRef.current) return;
+        stopPolling();
+        console.error("Error polling fetch status:", error);
+        setFetchError("Failed to check fetch status");
+      }
+    };
+
+    void poll();
+  }, [onFetchComplete, onTokenError, onUseAlbumError]);
 
   // Detect new sessions
   useEffect(() => {
@@ -74,7 +165,7 @@ export function useFetchSession(onFetchComplete?: () => void, onTokenError?: () 
         onSessionDetectedRef.current();
       }
     }
-  }, [latestSessionData, sessionPollingEnabled, sessionPollingRegion]);
+  }, [latestSessionData, sessionPollingEnabled, sessionPollingRegion, pollFetchStatus]);
 
   // tRPC mutation for starting fetch
   const startFetchMutation = trpc.user.startFetch.useMutation({
@@ -116,79 +207,21 @@ export function useFetchSession(onFetchComplete?: () => void, onTokenError?: () 
     return startDataFetch(region); // No token provided, will use saved token
   };
 
-  const pollFetchStatus = async (sessionId: string, region: Region) => {
-    const maxAttempts = 600; // 5 minutes max (300 seconds / 0.5 second = 600 attempts)
-    let attempts = 0;
 
-    const poll = async () => {
-      try {
-        // Query the latest fetch status directly using tRPC client
-        const result = await trpcClient.user.getFetchStatus.query({
-          region,
-        });
-
-        if (result && result.id === sessionId) {
-          // Only update if this is the session we're tracking
-          const updatedSession: FetchSession = {
-            id: result.id,
-            status: result.status,
-            startedAt: result.startedAt,
-            completedAt: result.completedAt || undefined,
-            errorMessage: result.errorMessage || undefined,
-            statusStates: result.statusStates || undefined,
-          };
-          console.log("Fetch status updated for session " + sessionId + " on " + region + " region: " + JSON.stringify(updatedSession));
-          setCurrentSession(updatedSession);
-
-          if (result.status === "completed") {
-            // Show warning toast for not found scores (separate from the custom toast)
-            if (result.notFoundScores && result.notFoundScores.length > 0) {
-              toast.warning(`${result.notFoundScores.length} songs not found in database`, {
-                description: result.notFoundScores.map(score => `${score.songName} (${score.difficulty})`).join(", "),
-              });
-            }
-            onFetchComplete?.();
-            return "completed";
-          } else if (result.status === "failed") {
-            const errorMessage = result.errorMessage || "Fetch failed";
-            setFetchError(errorMessage);
-
-            // Check if this is a token-related error and trigger callback
-            if (isTokenError(errorMessage)) {
-              onTokenError?.();
-            }
-
-            // Check if this is an album settings error
-            if (isAlbumSettingsError(errorMessage)) {
-              onUseAlbumError?.();
-            }
-
-            return "failed";
-          }
-        } else if (!result) {
-          // No fetch sessions found at all
-          setFetchError("Fetch session not found");
-          return "error";
-        }
-
-        attempts++;
-        if (attempts < maxAttempts) {
-          setTimeout(poll, 500); // Poll every 0.5 second
-        } else {
-          setFetchError("Fetch timeout");
-          return "timeout";
-        }
-      } catch (error) {
-        console.error("Error polling fetch status:", error);
-        setFetchError("Failed to check fetch status");
-        return "error";
-      }
-    };
-
-    return poll();
-  };
+  useEffect(() => () => {
+    fetchPollingGenerationRef.current++;
+    if (fetchPollingTimeoutRef.current !== null) {
+      window.clearTimeout(fetchPollingTimeoutRef.current);
+      fetchPollingTimeoutRef.current = null;
+    }
+  }, []);
 
   const resetFetchSession = useCallback(() => {
+    fetchPollingGenerationRef.current++;
+    if (fetchPollingTimeoutRef.current !== null) {
+      window.clearTimeout(fetchPollingTimeoutRef.current);
+      fetchPollingTimeoutRef.current = null;
+    }
     setCurrentSession(null);
     setFetchError(null);
   }, []);

--- a/apps/main/src/lib/api/schemas.ts
+++ b/apps/main/src/lib/api/schemas.ts
@@ -139,6 +139,10 @@ export const songCatalogueEntry = z.object({
   noteDesigner: z.string().nullable().describe("Chart designer name."),
 });
 
+export const songCatalogue = z.object({
+  songs: z.array(songCatalogueEntry),
+});
+
 export const songDetail = songCatalogueEntry.extend({
   noteCounts: z.object({
     tap: z.number().int().nullable(),

--- a/apps/main/src/lib/logger.ts
+++ b/apps/main/src/lib/logger.ts
@@ -137,7 +137,7 @@ type StreamEntry = { stream: { write: (chunk: string) => void } | NodeJS.Writabl
 const createServerLogger = (): Logger => {
   const pino = require("pino");
   const isEdge = process.env.NEXT_RUNTIME === "edge";
-  const baseLevel = process.env.LOG_LEVEL || "trace";
+  const baseLevel = process.env.LOG_LEVEL || (process.env.NODE_ENV === "development" ? "trace" : "info");
 
   if (isEdge) {
     return pino({ level: baseLevel }) as Logger;
@@ -162,7 +162,7 @@ const createServerLogger = (): Logger => {
         translateTime: "SYS:standard",
         ignore: "pid,hostname",
       }),
-      level: "debug",
+      level: baseLevel,
     });
   }
 
@@ -186,7 +186,7 @@ const createServerLogger = (): Logger => {
           }
         },
       },
-      level: "trace",
+      level: baseLevel,
     });
   }
 
@@ -195,7 +195,7 @@ const createServerLogger = (): Logger => {
     axiomFlush = axiom.flush;
     shippingStreams.push({
       stream: axiom.stream,
-      level: "trace",
+      level: baseLevel,
     });
   }
 
@@ -213,7 +213,7 @@ const createServerLogger = (): Logger => {
     return pino({ level: baseLevel }, pino.multistream(streams)) as Logger;
   }
 
-  return pino({ level: process.env.LOG_LEVEL || "info" }) as Logger;
+  return pino({ level: baseLevel }) as Logger;
 };
 
 // Use a global marker so the bridge is installed at most once across all

--- a/apps/main/src/lib/maimai/orchestrator.ts
+++ b/apps/main/src/lib/maimai/orchestrator.ts
@@ -7,6 +7,7 @@ import { fetchImageBuffer } from "../image-converter";
 import { logger } from "../logger";
 import { getCurrentVersion } from "../metadata";
 import { decryptToken } from "../token-crypto";
+import { revalidatePublicProfileForUser } from "../profile-cache";
 import { Region } from "../types";
 import {
   getCookiesFromRedirect,
@@ -339,6 +340,8 @@ async function persistFetchedData(
     await insertUserEvents(snapshotId, fetched.eventsData.areaEvents, fetched.eventsData.eventAreaEvents);
     logger.info("User events insertion completed");
   }
+
+  await revalidatePublicProfileForUser(userId, [region]);
 
   logger.info("Player data processed and snapshot created successfully");
   logger.info(`Session ID: ${sessionId}`);

--- a/apps/main/src/lib/profile-cache.ts
+++ b/apps/main/src/lib/profile-cache.ts
@@ -1,0 +1,34 @@
+import { locales } from "@tomomai/i18n/locale";
+import { eq } from "drizzle-orm";
+import { revalidatePath } from "next/cache";
+
+import { getEnabledRegions } from "@/lib/enabled-regions";
+import { db } from "@/lib/db";
+import { user } from "@/lib/db/schema-pg";
+import type { Region } from "@/lib/types";
+
+export function revalidatePublicProfile(
+  usernames: Array<string | null | undefined>,
+  regions: readonly Region[] = getEnabledRegions(),
+) {
+  const uniqueUsernames = new Set(usernames.filter((username): username is string => Boolean(username)));
+
+  for (const username of uniqueUsernames) {
+    const encodedUsername = encodeURIComponent(username);
+    for (const locale of locales) {
+      for (const region of regions) {
+        revalidatePath(`/${locale}/profile/${encodedUsername}/${region}`, "page");
+      }
+    }
+  }
+}
+
+export async function revalidatePublicProfileForUser(userId: string, regions?: readonly Region[]) {
+  const [record] = await db
+    .select({ username: user.username })
+    .from(user)
+    .where(eq(user.id, userId))
+    .limit(1);
+
+  if (record?.username) revalidatePublicProfile([record.username], regions);
+}

--- a/apps/main/src/lib/r2.ts
+++ b/apps/main/src/lib/r2.ts
@@ -13,6 +13,28 @@ export const r2Client = new S3Client({
 
 export const R2_BUCKET = process.env.R2_BUCKET!;
 
+export interface PutR2ObjectOptions {
+  key: string;
+  body: string | Uint8Array | Buffer;
+  contentType: string;
+  cacheControl: string;
+}
+
+export async function putR2Object({
+  key,
+  body,
+  contentType,
+  cacheControl,
+}: PutR2ObjectOptions): Promise<void> {
+  await r2Client.send(new PutObjectCommand({
+    Bucket: R2_BUCKET,
+    Key: key,
+    Body: body,
+    ContentType: contentType,
+    CacheControl: cacheControl,
+  }));
+}
+
 export async function uploadToR2(
   buffer: Buffer,
   contentType: string = "image/avif"

--- a/apps/main/src/lib/song-slug.ts
+++ b/apps/main/src/lib/song-slug.ts
@@ -96,11 +96,11 @@ const slugCache = new Map<string, { slug: string; aliases: string[] }>();
 async function computeSlugAndAliases(
   song: SongForSlug
 ): Promise<{ slug: string; aliases: string[] }> {
-  const processedName = await toRomaji(song.songName);
-  const processedArtist = await toRomaji(song.artist);
 
   const nameEverything = await toEverything(song.songName);
   const artistEverything = await toEverything(song.artist);
+  const processedName = nameEverything.romaji;
+  const processedArtist = artistEverything.romaji;
 
   const cleanedName = slug(processedName);
   const cleanedArtist = slug(processedArtist.replace(/\s+/g, ''));

--- a/apps/main/src/middleware.ts
+++ b/apps/main/src/middleware.ts
@@ -19,7 +19,7 @@ function isUnlocalizable(pathname: string): boolean {
   const lastSegment = pathname.split('/').pop() || '';
   if (/[./][a-zA-Z0-9]+$/.test(lastSegment)) return true;
   return (
-    pathname.startsWith('/api/') ||
+    (pathname === '/api' || pathname.startsWith('/api/')) ||
     pathname.startsWith('/.well-known/') ||
     pathname.startsWith('/cn-proxy/link') ||
     pathname.startsWith('/userscript') ||
@@ -65,6 +65,7 @@ function negotiateLocale(request: NextRequest): Locale {
 
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
+  const isApiPath = pathname === '/api' || pathname.startsWith('/api/');
 
   // Per-request correlation id (see docs/LOGGING.md).
   const inboundId = request.headers.get('x-request-id');
@@ -131,9 +132,8 @@ export async function middleware(request: NextRequest) {
     return stamp(securityResponse);
   }
 
-  // Forward pathname + request id to route handlers / pages.
+  // Forward the request id to route handlers / pages.
   const requestHeaders = new Headers(request.headers);
-  requestHeaders.set('x-pathname', pathname);
   requestHeaders.set('x-request-id', requestId);
 
   const response = NextResponse.next({ request: { headers: requestHeaders } });
@@ -144,17 +144,19 @@ export async function middleware(request: NextRequest) {
     response.headers.set(key, value);
   });
 
-  // Mirror Vercel edge-geo into a client-readable cookie for CDN routing.
-  const country = request.headers.get('x-vercel-ip-country');
-  if (country) {
-    const existing = request.cookies.get('country')?.value;
-    if (existing !== country) {
-      response.cookies.set('country', country, {
-        path: '/',
-        sameSite: 'lax',
-        maxAge: 60 * 60 * 24,
-        httpOnly: false,
-      });
+  // API responses must remain free of location cookies so shared CDN caches can store them.
+  if (!isApiPath) {
+    const country = request.headers.get('x-vercel-ip-country');
+    if (country) {
+      const existing = request.cookies.get('country')?.value;
+      if (existing !== country) {
+        response.cookies.set('country', country, {
+          path: '/',
+          sameSite: 'lax',
+          maxAge: 60 * 60 * 24,
+          httpOnly: false,
+        });
+      }
     }
   }
 
@@ -165,9 +167,9 @@ export async function middleware(request: NextRequest) {
 export const config = {
   runtime: 'nodejs',
   matcher: [
-    /*
-     * Match all request paths except static assets.
-     */
-    '/((?!_next/static|_next/image|favicon.ico|robots.txt|sitemap.xml).*)',
+    '/api/:path*',
+    '/.well-known/:path*',
+    '/res/fonts/:path*',
+    '/((?!_next/static|_next/image|.*\\.segments?(?:/|$)|.*\\.[^/]+$).*)',
   ],
 };

--- a/apps/main/src/server/routers/user/profile.ts
+++ b/apps/main/src/server/routers/user/profile.ts
@@ -8,6 +8,7 @@ import { z } from 'zod';
 import { getEnabledRegions, isCNExclusive } from '@/lib/enabled-regions';
 import { resolvePublicUserByUsername } from '@/server/queries/public-access';
 import { fetchProfileSettings } from '@/server/queries/profile';
+import { revalidatePublicProfile } from '@/lib/profile-cache';
 
 const regionSchema = z.enum(getEnabledRegions());
 
@@ -65,6 +66,17 @@ export const profileRouter = router({
       publishProfile: z.boolean(),
     }))
     .mutation(async ({ ctx, input }) => {
+      const [current] = await db
+        .select({ username: user.username, publishProfile: user.publishProfile })
+        .from(user)
+        .where(eq(user.id, ctx.session.user.id))
+        .limit(1);
+
+      if (!current) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'User not found' });
+      }
+      if (current.publishProfile === input.publishProfile) return { success: true };
+
       await db
         .update(user)
         .set({
@@ -73,6 +85,7 @@ export const profileRouter = router({
         })
         .where(eq(user.id, ctx.session.user.id));
 
+      revalidatePublicProfile([current.username]);
       return { success: true };
     }),
 
@@ -98,6 +111,15 @@ export const profileRouter = router({
     }))
     .mutation(async ({ ctx, input }) => {
       if (isCNExclusive()) throw new TRPCError({ code: 'BAD_REQUEST', message: 'Cannot update profile main region in China region' });
+      const [current] = await db
+        .select({ username: user.username, profileMainRegion: user.profileMainRegion })
+        .from(user)
+        .where(eq(user.id, ctx.session.user.id))
+        .limit(1);
+
+      if (!current) throw new TRPCError({ code: 'NOT_FOUND', message: 'User not found' });
+      if (current.profileMainRegion === input.profileMainRegion) return { success: true };
+
       await db
         .update(user)
         .set({
@@ -106,6 +128,7 @@ export const profileRouter = router({
         })
         .where(eq(user.id, ctx.session.user.id));
 
+      revalidatePublicProfile([current.username]);
       return { success: true };
     }),
 
@@ -119,19 +142,35 @@ export const profileRouter = router({
       profileShowInSearch: z.boolean(),
     }))
     .mutation(async ({ ctx, input }) => {
+      const [current] = await db
+        .select({
+          username: user.username,
+          profileShowAllScores: user.profileShowAllScores,
+          profileShowScoreDetails: user.profileShowScoreDetails,
+          profileShowPlates: user.profileShowPlates,
+          profileShowPlayCounts: user.profileShowPlayCounts,
+          profileShowEvents: user.profileShowEvents,
+          profileShowInSearch: user.profileShowInSearch,
+        })
+        .from(user)
+        .where(eq(user.id, ctx.session.user.id))
+        .limit(1);
+
+      if (!current) throw new TRPCError({ code: 'NOT_FOUND', message: 'User not found' });
+      const changed = Object.entries(input).some(
+        ([field, next]) => current[field as keyof typeof input] !== next,
+      );
+      if (!changed) return { success: true };
+
       await db
         .update(user)
         .set({
-          profileShowAllScores: input.profileShowAllScores,
-          profileShowScoreDetails: input.profileShowScoreDetails,
-          profileShowPlates: input.profileShowPlates,
-          profileShowPlayCounts: input.profileShowPlayCounts,
-          profileShowEvents: input.profileShowEvents,
-          profileShowInSearch: input.profileShowInSearch,
+          ...input,
           updatedAt: new Date(),
         })
         .where(eq(user.id, ctx.session.user.id));
 
+      revalidatePublicProfile([current.username]);
       return { success: true };
     }),
 

--- a/apps/main/src/server/routers/user/snapshots.ts
+++ b/apps/main/src/server/routers/user/snapshots.ts
@@ -15,6 +15,7 @@ import { TRPCError } from '@trpc/server';
 import { and, count, desc, eq, inArray, sql } from 'drizzle-orm';
 import { nanoid } from 'nanoid';
 import { z } from 'zod';
+import { revalidatePublicProfileForUser } from '@/lib/profile-cache';
 
 const regionSchema = z.enum(getEnabledRegions());
 
@@ -385,6 +386,7 @@ export const snapshotsRouter = router({
           message: 'Snapshot not found or access denied',
         });
       }
+      await revalidatePublicProfileForUser(ctx.session.user.id, [input.region]);
       return { success: true };
     }),
 
@@ -690,6 +692,7 @@ export const snapshotsRouter = router({
         .set({ rating: newRating })
         .where(eq(userSnapshots.id, newSnapshotInternalId));
 
+      await revalidatePublicProfileForUser(ctx.session.user.id, [input.region]);
       return {
         success: true,
         newSnapshotId: newSnapshotPublicId,

--- a/apps/main/src/server/routers/username.ts
+++ b/apps/main/src/server/routers/username.ts
@@ -6,6 +6,7 @@ import { TRPCError } from '@trpc/server';
 import { eq } from 'drizzle-orm';
 import { nanoid } from 'nanoid';
 import { z } from 'zod';
+import { revalidatePublicProfile } from '@/lib/profile-cache';
 
 // Username validation helper
 const isValidUsername = (username: string): boolean => {
@@ -90,7 +91,7 @@ export const usernameRouter = router({
 
       // Check if already taken (but allow current user's username)
       const existingUser = await db
-        .select({ id: user.id })
+        .select({ id: user.id, username: user.username })
         .from(user)
         .where(eq(user.username, input.username))
         .limit(1);
@@ -102,6 +103,16 @@ export const usernameRouter = router({
         });
       }
 
+      const [currentUser] = await db
+        .select({ username: user.username })
+        .from(user)
+        .where(eq(user.id, ctx.session.user.id))
+        .limit(1);
+      if (!currentUser) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'User not found' });
+      }
+      if (currentUser.username === input.username) return { success: true };
+
       // Update username
       await db
         .update(user)
@@ -110,6 +121,8 @@ export const usernameRouter = router({
           updatedAt: new Date(),
         })
         .where(eq(user.id, ctx.session.user.id));
+
+      revalidatePublicProfile([currentUser.username, input.username]);
 
       return { success: true };
     }),

--- a/apps/main/src/server/services/admin/song-catalog.ts
+++ b/apps/main/src/server/services/admin/song-catalog.ts
@@ -1,0 +1,49 @@
+import { db } from "@/lib/db";
+import { songs } from "@/lib/db/schema-pg";
+import { songCatalogue } from "@/lib/api/schemas";
+import { putR2Object } from "@/lib/r2";
+
+const SONG_CATALOG_R2_KEY = "api/v1/songs";
+
+/**
+ * Rebuilds the public catalog from committed rows, validates its public API
+ * contract once, serializes it once, then atomically replaces the stable R2
+ * object. Callers must await failures before reporting an update as complete.
+ */
+export async function publishSongCatalog(): Promise<{ songCount: number; bytes: number }> {
+  const catalog = {
+    songs: await db
+      .select({
+        songId: songs.publicId,
+        songName: songs.songName,
+        artist: songs.artist,
+        cover: songs.cover,
+        type: songs.type,
+        genre: songs.genre,
+        difficulty: songs.difficulty,
+        level: songs.level,
+        levelPrecise: songs.levelPrecise,
+        region: songs.region,
+        gameVersion: songs.gameVersion,
+        addedVersion: songs.addedVersion,
+        bpm: songs.bpm,
+        noteDesigner: songs.noteDesigner,
+      })
+      .from(songs)
+      .orderBy(songs.songName, songs.difficulty),
+  };
+
+  const validation = songCatalogue.safeParse(catalog);
+  if (!validation.success) {
+    throw new Error(`Public song catalog validation failed: ${validation.error.message}`);
+  }
+
+  const body = JSON.stringify(catalog);
+  await putR2Object({
+    key: SONG_CATALOG_R2_KEY,
+    body,
+    contentType: "application/json; charset=utf-8",
+    cacheControl: "public, max-age=3600",
+  });
+  return { songCount: catalog.songs.length, bytes: Buffer.byteLength(body) };
+}


### PR DESCRIPTION
## Summary

Reduce the Vercel meters currently dominating `maimai-friends`: Fast Origin Transfer, ISR Writes, Fluid Active CPU, Provisioned Memory, and Observability Events.

## What changed

### Move the public song catalog to R2

- Add a generic `putR2Object` storage primitive.
- Build the public catalog from committed rows, validate the shared API schema, serialize once, and atomically publish the stable R2 object.
- Publish after every non-noop admin update so a failed post-commit publication is retryable.
- Force broad song ISR invalidation when a recovery publication succeeds with no newly applied rows.
- Return a one-hour cached `302` from `/api/v1/songs` to the R2 object.
- Seed the production R2 object with the current 51,919-row, 17.9 MB catalog.

The previous response exceeded Vercel's 10 MB non-streaming CDN cache limit, so its cache headers could not prevent repeated Function output. At the observed 711 weekly invocations, approximately 12.7 GB/week of uncompressed response bodies can move off Vercel Functions.

### Narrow Node middleware

- Preserve API/auth rate limiting, API CORS, request IDs, locale routing, maintenance routing, `.well-known`, and font CORS.
- Exclude immutable/static assets and Next RSC `.segment` requests.
- Stop adding the country cookie to APIs so shared CDN caching is not bypassed.
- Remove unused `x-pathname` forwarding.

This targets the observed 311,022 middleware events over seven days and avoids middleware transfer on requests that do not need it.

### Reduce ISR writes

- Add exact locale × username × region invalidation after successful profile, privacy, username, and snapshot mutations.
- Raise profile fallback revalidation from 5 minutes to 1 hour only after mutation coverage is in place.
- Exclude unchanged catalog merges from song invalidation.
- Preserve old and new slugs for real renames.
- Make `robots.txt` fully static.

### Reduce compute, polling, and image work

- Default production shipping logs to `info`; keep development at `trace` and preserve explicit `LOG_LEVEL` overrides.
- Remove duplicate Japanese romanization while preserving slug and alias output.
- Change latest-session polling from 1s to 2s and status polling from 500ms to 1s, retaining an immediate first request and a true five-minute deadline.
- Prevent superseded polling generations from cancelling or overwriting active polling.
- Add accurate Next Image `sizes`, bypass Vercel transformations for R2 event art, and priority-load only one settings logo.

## External configuration completed

- R2 CORS permits public GET/HEAD and exposes ETag.
- Cloudflare caches `/api/v1/songs` for one hour.
- Live checks return Cloudflare `HIT` with increasing `Age` and no `Set-Cookie`.

## Deployment step

After production deployment, purge exactly:

```text
https://www.tomomai.lol/api/v1/songs
```

Cloudflare currently holds the old 200 response body. Purging lets the new cached 302 take effect immediately instead of waiting for the one-hour TTL.

## Verification

- `pnpm --filter @tomomai/site typecheck`
- `pnpm --filter @tomomai/site build`
- 45 focused Vitest tests passed
- Critical changed-file ESLint: 0 errors
- Production-mode smoke checks:
  - catalog route returns cached 302 with no country cookie
  - redirect follows to the valid 51,919-row R2 JSON
  - trusted-origin CORS and API request IDs remain
  - APIs stay in middleware while static assets bypass it
- Final reviewer pass found no remaining correctness blocker or style-only churn.

The full suite's only failure is the existing live Gamerch integration test: upstream no longer returns expected page `813771`.

## Not included / follow-ups

These remain separate because they carry larger migration or architecture risk relative to the immediate gain:

- Persist slugs/aliases in the database and remove request-time Kuromoji.
- Narrow global Kuromoji dictionary tracing after cold-bundle coverage can be proven.
- Complete remaining Sega image migration to R2.
- Split post/song/profile OG cache policies.
- Batch `getSimpleSongDetails` calls.
- Split songs/stats/events ISR route policies.
- Partition sitemap generation and add event-driven invalidation.
- Measure the percentile refresh before considering a database-native scheduler.
