### PR TITLE
fix(main): return profile 404s and remove Redis warnings

### DIFF
--- a/apps/guess/package.json
+++ b/apps/guess/package.json
@@ -22,7 +22,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "ffmpeg-static": "^5.3.0",
-    "ioredis": "^5.10.1",
+    "ioredis": "^5.11.1",
     "lucide-react": "^0.555.0",
     "motion": "^12.34.0",
     "next": "16.2.6",

--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -91,7 +91,7 @@
     "embla-carousel-react": "^8.6.0",
     "flags": "^4.0.3",
     "gray-matter": "^4.0.3",
-    "ioredis": "^5.10.1",
+    "ioredis": "^5.11.1",
     "jsdom": "^27.4.0",
     "kuromoji": "^0.1.2",
     "kuroshiro": "^1.2.0",

--- a/apps/main/src/app/[locale]/profile/[username]/[region]/page.tsx
+++ b/apps/main/src/app/[locale]/profile/[username]/[region]/page.tsx
@@ -1,6 +1,5 @@
 import { createServerSideTRPC } from "@/lib/trpc-server";
 import { TRPCError } from "@trpc/server";
-import { Region } from "@/lib/types";
 import { isRegionEnabledStr } from "@/lib/enabled-regions";
 import { ProfilePage } from "@/components/profile-page";
 import { notFound } from "next/navigation";
@@ -12,12 +11,7 @@ import { getLocale, setStaticLocale } from "@/i18n/locale-server";
 import { buildAlternates, openGraphLocales, breadcrumbJsonLd, ogImageUrl, localizePath } from "@/lib/seo";
 import { safeDecodeURIComponent } from "@/lib/utils";
 
-export const revalidate = 3600;
-export const dynamicParams = true;
-
-export function generateStaticParams() {
-  return [];
-}
+export const dynamic = "force-dynamic";
 
 interface RegionProfilePageProps {
   params: Promise<{

--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -19,7 +19,7 @@
   },
   "files": ["src"],
   "peerDependencies": {
-    "ioredis": "*",
+    "ioredis": "^5.11.1",
     "next": "*",
     "rate-limiter-flexible": "*"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,8 +56,8 @@ importers:
         specifier: ^5.3.0
         version: 5.3.0
       ioredis:
-        specifier: ^5.10.1
-        version: 5.10.1
+        specifier: ^5.11.1
+        version: 5.11.1
       lucide-react:
         specifier: ^0.555.0
         version: 0.555.0(react@19.2.6)
@@ -297,8 +297,8 @@ importers:
         specifier: ^4.0.3
         version: 4.0.3
       ioredis:
-        specifier: ^5.10.1
-        version: 5.10.1
+        specifier: ^5.11.1
+        version: 5.11.1
       jsdom:
         specifier: ^27.4.0
         version: 27.4.0(@noble/hashes@2.0.1)
@@ -555,8 +555,8 @@ importers:
   packages/security:
     dependencies:
       ioredis:
-        specifier: '*'
-        version: 5.10.1
+        specifier: ^5.11.1
+        version: 5.11.1
       next:
         specifier: '*'
         version: 16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -1870,8 +1870,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@ioredis/commands@1.5.1':
-    resolution: {integrity: sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==}
+  '@ioredis/commands@1.10.0':
+    resolution: {integrity: sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q==}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -4627,8 +4627,8 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
-  cluster-key-slot@1.1.2:
-    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+  cluster-key-slot@1.1.1:
+    resolution: {integrity: sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==}
     engines: {node: '>=0.10.0'}
 
   collapse-white-space@2.1.0:
@@ -5676,8 +5676,8 @@ packages:
   intl-messageformat@11.1.2:
     resolution: {integrity: sha512-ucSrQmZGAxfiBHfBRXW/k7UC8MaGFlEj4Ry1tKiDcmgwQm1y3EDl40u+4VNHYomxJQMJi9NEI3riDRlth96jKg==}
 
-  ioredis@5.10.1:
-    resolution: {integrity: sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==}
+  ioredis@5.11.1:
+    resolution: {integrity: sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==}
     engines: {node: '>=12.22.0'}
 
   ipaddr.js@2.3.0:
@@ -6136,12 +6136,6 @@ packages:
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
-
-  lodash.defaults@4.2.0:
-    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
-
-  lodash.isarguments@3.1.0:
-    resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
@@ -9016,7 +9010,7 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
-  '@ioredis/commands@1.5.1': {}
+  '@ioredis/commands@1.10.0': {}
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -11782,7 +11776,7 @@ snapshots:
 
   clsx@2.1.1: {}
 
-  cluster-key-slot@1.1.2: {}
+  cluster-key-slot@1.1.1: {}
 
   collapse-white-space@2.1.0: {}
 
@@ -13029,14 +13023,12 @@ snapshots:
       '@formatjs/icu-messageformat-parser': 3.5.1
       tslib: 2.8.1
 
-  ioredis@5.10.1:
+  ioredis@5.11.1:
     dependencies:
-      '@ioredis/commands': 1.5.1
-      cluster-key-slot: 1.1.2
+      '@ioredis/commands': 1.10.0
+      cluster-key-slot: 1.1.1
       debug: 4.4.3
       denque: 2.1.0
-      lodash.defaults: 4.2.0
-      lodash.isarguments: 3.1.0
       redis-errors: 1.2.0
       redis-parser: 3.0.0
       standard-as-callback: 2.1.0
@@ -13451,10 +13443,6 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
-
-  lodash.defaults@4.2.0: {}
-
-  lodash.isarguments@3.1.0: {}
 
   lodash.merge@4.6.2: {}
 


### PR DESCRIPTION
## Summary

- render localized profile detail routes dynamically so missing profiles and invalid regions return real 404 responses instead of static-to-dynamic 500s
- upgrade ioredis to 5.11.1 in main and guess, including the shared security peer requirement
- remove the Node 24 `url.parse()` deprecation warning emitted during Redis client initialization

## Why

The profile ISR route entered the localized `notFound()` boundary after static generation had started. `next-intl` then accessed request headers, which Next.js rejected as a static-to-dynamic transition. The route had low utilization (31 reads versus 158 writes in a sampled six-hour window), so dynamic rendering is cheaper and correct at its current traffic.

`ioredis` 5.10.1 used Node's deprecated `url.parse()` for connection strings. Its 5.11 release replaces that parser with the WHATWG URL API.

## Verification

- missing or invalid profile: HTTP 404 with private/no-store cache policy
- existing profile: HTTP 200
- main production build passed with `NODE_OPTIONS=--trace-deprecation`
- guess production build passed with `NODE_OPTIONS=--trace-deprecation`
- neither build emitted DEP0169 after the dependency upgrade


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Profile pages now consistently display the latest dynamic content instead of relying on cached or pre-generated pages.

* **Maintenance**
  * Updated Redis support to version 5.11.1 across the application.
  * Aligned the security package’s Redis compatibility requirements with the updated version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->