### PR TITLE
fix(main): validate exact image proxy hosts

### DIFF
--- a/apps/main/src/app/api/image-proxy/route.ts
+++ b/apps/main/src/app/api/image-proxy/route.ts
@@ -3,7 +3,7 @@ import { Agent } from 'undici';
 import { getCachedImageBuffer, cacheImage } from '@/lib/image_cacher';
 import { flushLogger } from '@/lib/logger';
 import { requestLogger } from '@/lib/request-logger';
-import { SAFE_MAIMAI_IMAGE_URLS } from '@/lib/utils';
+import { isSafeMaimaiImageUrl } from '@/lib/utils';
 
 export async function GET(request: NextRequest) {
   const { log, requestId } = requestLogger(request, "image-proxy");
@@ -14,8 +14,8 @@ export async function GET(request: NextRequest) {
     return new NextResponse('Missing url parameter', { status: 400 });
   }
 
-  // Validate that this is a maimaidx domain for security
-  if (!SAFE_MAIMAI_IMAGE_URLS.some(domain => imageUrl.includes(domain))) {
+  // Only fetch exact HTTPS hosts from the cover-image allowlist.
+  if (!isSafeMaimaiImageUrl(imageUrl)) {
     return new NextResponse('Unauthorized domain', { status: 403 });
   }
 

--- a/apps/main/src/lib/image_cacher.ts
+++ b/apps/main/src/lib/image_cacher.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'crypto';
-import { SAFE_MAIMAI_IMAGE_URLS, isServer, isServerless } from './utils';
+import { isSafeMaimaiImageUrl, isServer, isServerless } from './utils';
 import { gzip, gunzip } from 'zlib';
 import { promisify } from 'util';
 import path from 'path';
@@ -14,20 +14,11 @@ function generateUrlHash(url: string): string {
   return createHash('md5').update(url).digest('hex');
 }
 
-// Check if URL is from allowed maimaidx domains
-function isMaimaidxDomain(url: string): boolean {
-  try {
-    const urlObj = new URL(url);
-    return SAFE_MAIMAI_IMAGE_URLS.some(domain => urlObj.hostname.includes(domain))
-  } catch {
-    return false;
-  }
-}
 
 // Cache and return local path for maimaidx images
 export async function cacheImage(url: string): Promise<void> {
   // Only cache on server and for maimaidx domains
-  if (!isServer() || !isMaimaidxDomain(url) || isServerless()) {
+  if (!isServer() || !isSafeMaimaiImageUrl(url) || isServerless()) {
     return;
   }
 
@@ -82,7 +73,7 @@ export async function cacheImage(url: string): Promise<void> {
 
 // Get cached image buffer for API routes
 export async function getCachedImageBuffer(url: string): Promise<{ buffer: Buffer; contentType: string } | null> {
-  if (!isServer() || !isMaimaidxDomain(url)) {
+  if (!isServer() || !isSafeMaimaiImageUrl(url)) {
     return null;
   }
 

--- a/apps/main/src/lib/utils.ts
+++ b/apps/main/src/lib/utils.ts
@@ -20,6 +20,21 @@ export const SAFE_MAIMAI_IMAGE_URLS = [
   'maimai.sega.jp',
 ]
 
+export function isSafeMaimaiImageUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return (
+      url.protocol === 'https:' &&
+      url.username === '' &&
+      url.password === '' &&
+      url.port === '' &&
+      SAFE_MAIMAI_IMAGE_URLS.includes(url.hostname)
+    );
+  } catch {
+    return false;
+  }
+}
+
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
@@ -72,7 +87,7 @@ export function getLogoUrl(gameVersion: number, region: "intl" | "jp" | "cn"): s
 // Sync version for client-side React components
 export function createSafeMaimaiImageUrl(originalUrl: string): string {
   // Check if it's a maimaidx domain
-  if (SAFE_MAIMAI_IMAGE_URLS.some(domain => originalUrl.includes(domain))) {
+  if (isSafeMaimaiImageUrl(originalUrl)) {
     // On client side, always use proxy (cache check would require server-side APIs)
     const encodedUrl = encodeURIComponent(originalUrl);
     return `/api/image-proxy?url=${encodedUrl}`;


### PR DESCRIPTION
## Summary

- parse cover URLs with the WHATWG URL API before proxying or caching them
- require HTTPS, an exact allowlisted hostname, no credentials, and no custom port
- reuse the same validator in the browser URL helper, image proxy route, and filesystem image cache

## Why

The previous checks used substring matching against the full URL or hostname. Values such as `https://evil.test/?host=maimaidx.jp`, `https://evilmaimaidx.jp/`, or `https://maimaidx.jp.evil.test/` could pass and make the server fetch an attacker-controlled origin.

## Verification

- focused validation covered all four allowed hosts and rejected HTTP, credentials, custom ports, subdomains, prefix/suffix lookalikes, path/query-string matches, and malformed URLs
- `pnpm --filter @tomomai/site typecheck` passed
- `pnpm --filter @tomomai/site build` passed
