### PR TITLE
perf(main): reduce background origin requests

### DIFF
--- a/apps/main/src/app/api/pre-maintenance/route.ts
+++ b/apps/main/src/app/api/pre-maintenance/route.ts
@@ -4,8 +4,14 @@ import { parsePreMaintenanceBanner } from "./parse";
 
 const CACHE_HEADERS = {
   "Cache-Control": "public, max-age=300",
-  "CDN-Cache-Control": "public, s-maxage=300",
-  "Vercel-CDN-Cache-Control": "public, s-maxage=300",
+  "CDN-Cache-Control": "public, max-age=300",
+  "Vercel-CDN-Cache-Control": "public, max-age=300",
+} as const;
+
+const NO_STORE_HEADERS = {
+  "Cache-Control": "no-store",
+  "CDN-Cache-Control": "no-store",
+  "Vercel-CDN-Cache-Control": "no-store",
 } as const;
 
 export async function GET() {
@@ -18,7 +24,7 @@ export async function GET() {
   } catch {
     return NextResponse.json(
       { banner: null },
-      { status: 503, headers: CACHE_HEADERS },
+      { status: 503, headers: NO_STORE_HEADERS },
     );
   }
 }

--- a/apps/main/src/components/site-footer.tsx
+++ b/apps/main/src/components/site-footer.tsx
@@ -14,6 +14,7 @@ function FooterLink({ href, children }: { href: string; children: React.ReactNod
   return (
     <Link
       href={href}
+      prefetch={false}
       className="text-muted-foreground/80 transition-colors hover:text-foreground"
     >
       {children}

--- a/apps/main/src/hooks/useFetchSession.ts
+++ b/apps/main/src/hooks/useFetchSession.ts
@@ -6,6 +6,10 @@ import { isTokenError, isAlbumSettingsError, isCnCookiesSingleUseError } from "@
 import { parseStatusStates } from "@/lib/fetch-states";
 import { FetchToastState } from "@/components/fetch-toast";
 
+const SESSION_DETECTION_INTERVAL_MS = 3000;
+const FETCH_STATUS_INTERVAL_MS = 2000;
+const HIDDEN_TAB_RECHECK_INTERVAL_MS = 5000;
+
 export function useFetchSession(onFetchComplete?: () => void, onTokenError?: () => void, onUseAlbumError?: () => void, onCnCookiesExpired?: () => void) {
   const [currentSession, setCurrentSession] = useState<FetchSession | null>(null);
   const [fetchError, setFetchError] = useState<string | null>(null);
@@ -24,7 +28,8 @@ export function useFetchSession(onFetchComplete?: () => void, onTokenError?: () 
     { region: sessionPollingRegion! },
     {
       enabled: sessionPollingEnabled && sessionPollingRegion !== null,
-      refetchInterval: 2000, // Poll every 2 seconds
+      refetchInterval: SESSION_DETECTION_INTERVAL_MS,
+      refetchIntervalInBackground: false,
       refetchOnWindowFocus: false,
     }
   );
@@ -50,6 +55,14 @@ export function useFetchSession(onFetchComplete?: () => void, onTokenError?: () 
       if (Date.now() >= deadline) {
         stopPolling();
         setFetchError("Fetch timeout");
+        return;
+      }
+
+      if (document.visibilityState === "hidden") {
+        fetchPollingTimeoutRef.current = window.setTimeout(
+          poll,
+          Math.min(HIDDEN_TAB_RECHECK_INTERVAL_MS, deadline - Date.now()),
+        );
         return;
       }
 
@@ -106,7 +119,7 @@ export function useFetchSession(onFetchComplete?: () => void, onTokenError?: () 
           setFetchError("Fetch timeout");
           return;
         }
-        fetchPollingTimeoutRef.current = window.setTimeout(poll, Math.min(1000, remaining));
+        fetchPollingTimeoutRef.current = window.setTimeout(poll, Math.min(FETCH_STATUS_INTERVAL_MS, remaining));
       } catch (error) {
         if (generation !== fetchPollingGenerationRef.current) return;
         stopPolling();


### PR DESCRIPTION
## Summary
- stop `next/link` from automatically prefetching `/privacy` and `/tos` from the shared footer
- use Vercel's targeted CDN cache syntax for `/api/pre-maintenance` and avoid caching failure responses
- reduce fetch-session polling frequency and pause status polling while the tab is hidden

## Why
Production traffic showed roughly 2,483 `/privacy` and 1,929 `/tos` requests per day. Both links were mounted in the footer of every localized page with default Next.js prefetch behavior, and each static cache hit still entered middleware. `/api/pre-maintenance` was also reaching origin about 414 times per day because its targeted CDN headers used `s-maxage`; Vercel's targeted headers require `max-age`.

PR #39 was not revived: its SSE implementation kept a serverless connection open while continuing to poll the database, shifting rather than eliminating work and adding active CPU/provisioned-memory exposure.

## Verification
- `pnpm --filter @tomomai/site build`
- production-mode browser smoke: `/en/db` made no `/privacy` or `/tos` prefetch request
- `/api/pre-maintenance` returned `Cache-Control`, `CDN-Cache-Control`, and `Vercel-CDN-Cache-Control` as `public, max-age=300`
- signed commit verified with `git verify-commit HEAD`