### PR TITLE
fix(security): trust proxy-controlled client IP headers

### DIFF
--- a/apps/main/src/lib/auth.ts
+++ b/apps/main/src/lib/auth.ts
@@ -13,7 +13,7 @@ import { db } from "./db";
 import * as schema from "./db/schema-pg";
 import { logger } from "@/lib/logger";
 import { consumeAltchaPayload } from "@/lib/altcha";
-import { passkeyRegisterLimiter } from "@/lib/security/redis-rate-limit";
+import { clientIpFromHeaders, passkeyRegisterLimiter } from "@/lib/security/redis-rate-limit";
 import { isSessionFresh } from "@/lib/security/fresh-session";
 import { isSafeRedirectUrl, isSafeWebUrl, isHttpsUrl } from "@/lib/security/oauth-url";
 import { mirrorRemoteAvatarToR2, isR2AvatarUrl } from "@/lib/r2";
@@ -303,6 +303,14 @@ export const auth = betterAuth({
     // — there is no path where an untrusted client can reach the app
     // without going through one of them.
     trustedProxyHeaders: true,
+    ipAddress: {
+      ipAddressHeaders: [
+        "x-vercel-forwarded-for",
+        "cf-connecting-ip",
+        "x-forwarded-for",
+        "x-real-ip",
+      ],
+    },
     ...(authCookieDomain
       ? {
         crossSubDomainCookies: { enabled: true, domain: authCookieDomain },
@@ -592,12 +600,7 @@ export const auth = betterAuth({
       if (!CAPTCHA_GATED_PATHS.has(ctx.path)) return;
 
       // Per-IP rate limit on the abuse outcome itself, in addition to the captcha.
-      const ipHeader =
-        ctx.headers?.get("cf-connecting-ip") ??
-        ctx.headers?.get("x-forwarded-for") ??
-        ctx.headers?.get("x-real-ip") ??
-        "unknown";
-      const ip = ipHeader.split(",")[0].trim();
+      const ip = ctx.headers ? clientIpFromHeaders(ctx.headers) : "unknown";
       const rl = await passkeyRegisterLimiter.check(ip);
       if (rl.limited) {
         throw new APIError("TOO_MANY_REQUESTS", {

--- a/apps/main/src/lib/security/client-ip.test.ts
+++ b/apps/main/src/lib/security/client-ip.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { clientIpFromHeaders } from "@tomomai/security/rate-limit";
+
+describe("clientIpFromHeaders", () => {
+  it("prefers Vercel's protected client IP over proxy-supplied headers", () => {
+    const headers = new Headers({
+      "x-vercel-forwarded-for": "203.0.113.10",
+      "cf-connecting-ip": "198.51.100.20",
+      "x-forwarded-for": "192.0.2.30",
+    });
+
+    expect(clientIpFromHeaders(headers)).toBe("203.0.113.10");
+  });
+
+  it("uses Cloudflare's connecting IP before the forwarded chain", () => {
+    const headers = new Headers({
+      "cf-connecting-ip": "2001:db8::10",
+      "x-forwarded-for": "192.0.2.30, 198.51.100.40",
+    });
+
+    expect(clientIpFromHeaders(headers)).toBe("2001:db8::10");
+  });
+
+  it("falls back to the first valid forwarded IP outside Vercel and Cloudflare", () => {
+    const headers = new Headers({
+      "x-forwarded-for": "192.0.2.30, 198.51.100.40",
+    });
+
+    expect(clientIpFromHeaders(headers)).toBe("192.0.2.30");
+  });
+
+  it("ignores malformed values instead of creating attacker-controlled Redis keys", () => {
+    const headers = new Headers({
+      "x-vercel-forwarded-for": "not-an-ip",
+      "cf-connecting-ip": "also-not-an-ip",
+      "x-forwarded-for": "still-not-an-ip",
+    });
+
+    expect(clientIpFromHeaders(headers)).toBe("unknown");
+  });
+});

--- a/apps/main/src/lib/security/redis-rate-limit.ts
+++ b/apps/main/src/lib/security/redis-rate-limit.ts
@@ -1,4 +1,9 @@
-import { RedisRateLimiter, clientIp, rateLimit } from "@tomomai/security/rate-limit";
+import {
+  RedisRateLimiter,
+  clientIp,
+  clientIpFromHeaders,
+  rateLimit,
+} from "@tomomai/security/rate-limit";
 import { logger } from "../logger";
 import { TIER_I } from "@/lib/api/tiers";
 
@@ -6,7 +11,7 @@ export type {
   RateLimitOptions,
   RateLimitResult,
 } from "@tomomai/security/rate-limit";
-export { RedisRateLimiter, clientIp, rateLimit };
+export { RedisRateLimiter, clientIp, clientIpFromHeaders, rateLimit };
 
 // --- Shared limiter instances ---
 

--- a/packages/security/src/rate-limit.ts
+++ b/packages/security/src/rate-limit.ts
@@ -1,3 +1,4 @@
+import { isIP } from "node:net";
 import { NextRequest, NextResponse } from "next/server";
 import { RateLimiterRedis, RateLimiterRes } from "rate-limiter-flexible";
 import { getRedis } from "./redis";
@@ -27,14 +28,30 @@ export interface RateLimitResult {
   headers: Record<string, string>;
 }
 
-/** Extracts client IP from common proxy headers. Vercel sets x-forwarded-for. */
+const CLIENT_IP_HEADERS = [
+  "x-vercel-forwarded-for",
+  "cf-connecting-ip",
+  "x-forwarded-for",
+  "x-real-ip",
+] as const;
+
+type HeaderReader = { get(name: string): string | null };
+
+/** Extracts a validated client IP, preferring headers controlled by Vercel and Cloudflare. */
+export function clientIpFromHeaders(headers: HeaderReader): string {
+  for (const name of CLIENT_IP_HEADERS) {
+    const raw = headers.get(name);
+    if (!raw) continue;
+
+    const candidate = raw.split(",")[0]!.trim();
+    if (isIP(candidate)) return candidate;
+  }
+
+  return "unknown";
+}
+
 export function clientIp(req: NextRequest): string {
-  const raw =
-    req.headers.get("cf-connecting-ip") ??
-    req.headers.get("x-forwarded-for") ??
-    req.headers.get("x-real-ip") ??
-    "unknown";
-  return raw.split(",")[0]!.trim();
+  return clientIpFromHeaders(req.headers);
 }
 
 /**


### PR DESCRIPTION
## Summary
- prefer Vercel- and Cloudflare-controlled client IP headers
- validate addresses before using them as Redis rate-limit keys
- align Better Auth session and passkey IP resolution with rate limiting

## Verification
- `pnpm exec vitest run src/lib/security/client-ip.test.ts`
- `pnpm run typecheck`
- `pnpm exec tsc --noEmit` in `packages/security`
- `pnpm run build`
- live Cloudflare session and OAuth cookie smoke checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Improved client IP detection across common proxy and hosting environments.
  * Rate limiting now uses validated IP addresses, helping prevent inaccurate or bypassed passkey registration limits.
  * Invalid or malformed IP header values are rejected instead of being trusted.
* **Bug Fixes**
  * Corrected proxy header precedence to consistently identify the originating client address.
  * Added a safe fallback when no valid client IP can be determined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->