### PR TITLE
perf(main/db): rate limit song detail requests

### DIFF
--- a/apps/main/src/lib/security/middleware.ts
+++ b/apps/main/src/lib/security/middleware.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { apiLimiter, authLimiter, clientIp } from './redis-rate-limit';
+import { apiLimiter, authLimiter, clientIp, songDetailLimiter } from './redis-rate-limit';
 import { CORS_CONFIG } from './config';
 import { logger } from '../logger';
+import { locales } from '@tomomai/i18n/locale';
 
 /**
  * Security middleware that combines multiple security features:
@@ -125,6 +126,16 @@ function isStrictAuthPath(path: string): boolean {
   return STRICT_AUTH_PREFIXES.some((prefix) => path.startsWith(prefix));
 }
 
+function isSongDetailPath(path: string): boolean {
+  const segments = path.split('/');
+  return (segments.length === 5 || (segments.length === 6 && segments[5] === ''))
+    && segments[0] === ''
+    && (locales as readonly string[]).includes(segments[1]!)
+    && segments[2] === 'db'
+    && segments[3] === 'songs'
+    && segments[4] !== '';
+}
+
 /**
  * Check rate limiting based on request path
  */
@@ -136,7 +147,10 @@ async function checkRateLimiting(request: NextRequest, path: string): Promise<{
     let limiter: typeof apiLimiter | null = null;
     let message = "Too many requests. Please try again later.";
 
-    if (isStrictAuthPath(path)) {
+    if (isSongDetailPath(path)) {
+      limiter = songDetailLimiter;
+      message = "Too many song detail requests. Please try again later.";
+    } else if (isStrictAuthPath(path)) {
       limiter = authLimiter;
       message = "Too many authentication attempts. Please try again later.";
     } else if (path.startsWith('/api/')) {

--- a/apps/main/src/lib/security/redis-rate-limit.ts
+++ b/apps/main/src/lib/security/redis-rate-limit.ts
@@ -18,6 +18,16 @@ export const apiLimiter = new RedisRateLimiter({
   logger,
 });
 
+/** Localized song detail pages share one per-IP bucket across all slugs. */
+export const songDetailLimiter = new RedisRateLimiter({
+  name: "song-detail",
+  windowSeconds: 60,
+  max: 10,
+  blockSeconds: 10 * 60,
+  failClosed: false,
+  logger,
+});
+
 /** Auth endpoints, stricter than general API. */
 export const authLimiter = new RedisRateLimiter({
   name: "auth",


### PR DESCRIPTION
## Summary
- apply a dedicated per-client-IP Redis bucket only to localized song detail pages
- allow 10 requests per 60 seconds, then block that IP for 10 minutes
- aggregate all song slugs into the same bucket to bound wide crawler fan-out
- preserve fail-open behavior when Redis is unavailable

`CF-Connecting-IP` remains the first client-IP source, ahead of forwarding headers. Song list pages, APIs, other database detail routes, unsupported locales, and nested paths are excluded.

## Verification
- `pnpm --filter @tomomai/site typecheck --pretty false`
- `pnpm --filter @tomomai/site build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protection for localized song detail pages by limiting repeated requests from the same IP address.
  * Added a dedicated cooldown after the request threshold is exceeded, helping maintain page availability.
  * Users who exceed the limit now receive a clearer rate-limit notification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->