### PR TITLE
perf(main/db): restore bounded song SEO discovery

### DIFF
--- a/apps/main/src/app/[locale]/db/[type]/[slug]/page.tsx
+++ b/apps/main/src/app/[locale]/db/[type]/[slug]/page.tsx
@@ -3,7 +3,7 @@ import { getAllUniqueSongsCached } from "@/server/queries/songs-cache";
 import { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 import { getLocale } from "@/i18n/locale-server";
-import { breadcrumbJsonLd, openGraphLocales, ogImageUrl, localizePath } from "@/lib/seo";
+import { buildAlternates, breadcrumbJsonLd, openGraphLocales, ogImageUrl, localizePath } from "@/lib/seo";
 import { resolveBaseUrl } from "@/lib/base-url";
 import { safeDecodeURIComponent } from "@/lib/utils";
 
@@ -72,7 +72,7 @@ export async function generateMetadata({ params }: DbSlugPageProps): Promise<Met
   return {
     title,
     description,
-    robots: { index: false, follow: false },
+    alternates: await buildAlternates(path),
     openGraph: {
       title,
       description: ogDescription,

--- a/apps/main/src/app/[locale]/db/[type]/page.tsx
+++ b/apps/main/src/app/[locale]/db/[type]/page.tsx
@@ -1,3 +1,4 @@
+import { SongListSeo } from "@/components/db/songs/song-list-seo";
 import { getAllUniqueSongsCached } from "@/server/queries/songs-cache";
 import { Metadata } from "next";
 import dynamic from "next/dynamic";
@@ -7,8 +8,9 @@ import { getLocale } from "@/i18n/locale-server";
 import { buildAlternates, openGraphLocales, ogImageUrl, localizePath } from "@/lib/seo";
 import { DB_TYPES } from "@/lib/db/types";
 
-// On-demand ISR.
-export const revalidate = 10800;
+// On-demand ISR. Catalog uploads explicitly revalidate this route; 30 days is
+// the fallback freshness window.
+export const revalidate = 2592000;
 
 export async function headers() {
   return {
@@ -75,7 +77,8 @@ export default async function DbTypePage({ params }: DbTypePageProps) {
 
   if (type === "songs") {
     // The interactive SongsList is mounted by /db/[type]/layout so it
-    // persists across list ↔ detail navigation.
+    // persists across list ↔ detail navigation. This page emits the complete
+    // server-rendered link list for discovery plus the catalog JSON-LD.
     const songs = await getAllUniqueSongsCached();
     const t = await getTranslations("db.songs.metadata");
 
@@ -93,6 +96,7 @@ export default async function DbTypePage({ params }: DbTypePageProps) {
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
         />
+        <SongListSeo />
       </>
     );
   }

--- a/apps/main/src/app/sitemap.ts
+++ b/apps/main/src/app/sitemap.ts
@@ -6,6 +6,7 @@ import { and, eq, isNotNull, sql } from 'drizzle-orm';
 import { db } from '@/lib/db';
 import { getAllPostsMeta, getAvailableTranslations } from '@/lib/posts';
 import { defaultLocale } from '@/i18n/locale';
+import { getAllUniqueSongsCached } from '@/server/queries/songs-cache';
 
 /** Build a localized absolute URL for the sitemap. */
 const loc = (baseUrl: string, path: string) =>
@@ -36,6 +37,15 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     .groupBy(user.id, user.username)
     .orderBy(sql`${latestSnapshotAt} desc nulls last`)
     .limit(50);
+
+  // Keep discovery aligned with SongListSeo: use the same cached catalog
+  // sequence and bound only the sitemap projection.
+  const catalogSongs = await getAllUniqueSongsCached();
+  const songSitemapItems = catalogSongs.slice(0, 100).map((song) => ({
+    url: loc(baseUrl, `/db/songs/${encodeURIComponent(song.slug)}`),
+    changeFrequency: 'monthly',
+    priority: 0.55,
+  }) satisfies SitemapItem);
   // Get all posts for sitemap (using English as base)
   const posts = getAllPostsMeta('en');
   const postSitemapItems = posts.map((post) => {
@@ -76,5 +86,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: 'weekly',
       priority: 0.6,
     }) satisfies SitemapItem),
+    ...songSitemapItems,
   ]
 }

--- a/apps/main/src/components/db/songs-list.tsx
+++ b/apps/main/src/components/db/songs-list.tsx
@@ -28,9 +28,10 @@ interface SongsListProps {
  * Mounted in /db/[type]/layout.tsx so it NEVER unmounts across
  * /db/songs ↔ /db/songs/[slug] navigation: filter/search/scroll/visible-count
  * state survives in plain React state, and the catalog survives in the tRPC
- * cache (1h). No `initialSongs` prop is accepted — passing it would
- * serialize the whole catalog into the shared layout's RSC segment and
- * leak onto the detail route's ISR payload.
+ * cache (1h). No `initialSongs` prop is accepted — passing it would serialize
+ * the whole catalog into the shared layout's RSC segment and leak onto the
+ * detail route's ISR payload. The /db/songs page renders a separate SSR list
+ * of song links, which this component hides after hydration.
  */
 export function SongsList(_: SongsListProps = {}) {
   const t = useTranslations();
@@ -67,6 +68,12 @@ export function SongsList(_: SongsListProps = {}) {
 
   useEffect(() => {
     setMounted(true);
+  }, []);
+
+  // Replace the crawler-facing SSR list with the interactive catalog after
+  // hydration while leaving the complete link list in the initial HTML.
+  useEffect(() => {
+    document.getElementById("songs-seo-list")?.setAttribute("hidden", "");
   }, []);
 
   const [displayMode, setDisplayMode] = useState<"grid" | "list">("grid");

--- a/apps/main/src/components/db/songs/song-list-seo.tsx
+++ b/apps/main/src/components/db/songs/song-list-seo.tsx
@@ -1,0 +1,27 @@
+import { getAllUniqueSongsCached } from "@/server/queries/songs-cache";
+
+/**
+ * Server-rendered, crawler-facing list of song links for the /db/songs route.
+ *
+ * SongsList (the interactive grid) lives in the shared /db/[type]/layout and
+ * is client-fetched via tRPC — so song cards are not in the initial HTML.
+ * This component puts real, crawlable song names and detail-page links in the
+ * SSR document so the complete catalog stays discoverable. SongsList hides it
+ * once the interactive grid hydrates.
+ *
+ * Rendered only by the list page, so it never leaks onto /db/songs/[slug].
+ */
+export async function SongListSeo() {
+  const songs = await getAllUniqueSongsCached();
+  return (
+    <ul id="songs-seo-list" className="sr-only">
+      {songs.map((song) => (
+        <li key={`${song.slug}-${song.type}`}>
+          <a href={`/db/songs/${encodeURIComponent(song.slug)}`}>
+            {song.songName || song.artist}
+          </a>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/main/src/server/queries/songs.ts
+++ b/apps/main/src/server/queries/songs.ts
@@ -164,6 +164,8 @@ export async function querySongDetails(
 }
 
 export async function queryAllUniqueSongs() {
+  // Uploads invalidate this tag and the affected routes; 30 days is only the
+  // fallback freshness window shared by the list, detail, and sitemap routes.
   const getCachedUniqueSongs = unstable_cache(
     async () => {
       const allSongs = await db
@@ -269,7 +271,7 @@ export async function queryAllUniqueSongs() {
       return songsStripped;
     },
     ["all-unique-songs"],
-    { revalidate: 3600, tags: ["all-unique-songs"] }
+    { revalidate: 2592000, tags: ["all-unique-songs"] }
   );
 
   return getCachedUniqueSongs();


### PR DESCRIPTION
## Summary
- restore the complete server-rendered song link catalog on the song list page
- restore canonical/language alternates and indexing for valid song detail pages
- keep unknown song slugs `noindex, nofollow`
- include only the first 100 catalog-ordered songs in the sitemap
- use a 30-day fallback for the song list, song details, and shared catalog cache, with existing upload-driven tag/path invalidation

The sitemap keeps its six-hour refresh and the 50 newest snapshot-backed profile limit. PR #69's font headers, image-proxy caching, middleware cleanup, and other cost cuts remain unchanged.

## Verification
- `pnpm run typecheck`
- `pnpm --filter @tomomai/site build` — `/en/db/songs` reports a 30-day revalidate; sitemap remains six hours
- production-mode browser smoke — 1,644 server-rendered song links, exactly 100 sitemap song URLs in matching order, valid detail has canonical/no robots exclusion, unknown detail has `noindex, nofollow`