### PR TITLE
fix(main/recommendations): exclude utage charts from recommendations

### DIFF
--- a/apps/main/src/server/queries/recommendations.ts
+++ b/apps/main/src/server/queries/recommendations.ts
@@ -39,6 +39,9 @@ export function generateRecommendations(songsWithRating: SongWithRating[], versi
   const oldSongsRemainingTuple = oldSongsRemaining.map(song => ({ song, isNew: false }));
 
   [...newSongsB15Tuple, ...oldSongsB35Tuple, ...newSongsRemainingTuple, ...oldSongsRemainingTuple].forEach(({ song, isNew }) => {
+    // utage charts never contribute rating; recommending them would show a fake rating gain
+    if (song.difficulty === "utage") return;
+
     const isInB15 = isNew && newSongsB15.some(s => s.songId === song.songId && s.difficulty === song.difficulty);
     const isInB35 = !isNew && oldSongsB35.some(s => s.songId === song.songId && s.difficulty === song.difficulty);
     const isInBest = isInB15 || isInB35;


### PR DESCRIPTION
## Problem

Users report getting utage charts in their recommendations even though utage charts contribute 0 rating (`calculateSongRating` returns 0 for `difficulty === "utage"`).

The 0-rating fix only kept utage out of the B50 buckets — `generateRecommendations` never filters by difficulty. For a non-best chart, the admission guard compares the chart's **hypothetical max rating** (derived from `levelPrecise`, which utage charts have as a real value like 14.0 → ~316) against the B15/B35 minimum. So a 13+/14+ utage chart passes the guard and gets recommended with `currentRating: 0` and a large fake `ratingGain`.

Affects both the dashboard RecommendationCard and the Discord `/recommend` command — they share `generateRecommendations`.

## Fix

Skip `difficulty === "utage"` in the recommendation candidate loop.

Verified locally: a reproduction scenario (B15 minimum 258 + 14.0 utage at 0%) recommends the utage chart pre-fix with ratingGain ~316 and no longer does post-fix; a normal 14.0 chart in the same bucket is still recommended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Songs marked as “utage” are now excluded from recommendation calculations.
  * These songs no longer generate recommendations or affect rating gains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->